### PR TITLE
Hotfix: Fix allPackages not affecting count.

### DIFF
--- a/cmd/yaylog/main.go
+++ b/cmd/yaylog/main.go
@@ -46,7 +46,7 @@ func main() {
 
 	pkgdata.SortPackages(packages, cfg.SortBy)
 
-	if cfg.Count > 0 && len(packages) > cfg.Count {
+	if cfg.Count > 0 && !cfg.AllPackages && len(packages) > cfg.Count {
 		packages = packages[:cfg.Count]
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,6 +61,7 @@ func ParseFlags(args []string) Config {
 
 	return Config{
 		Count:            count,
+		AllPackages:      allPackages,
 		ShowHelp:         showHelp,
 		ExplicitOnly:     explicitOnly,
 		DependenciesOnly: dependenciesOnly,


### PR DESCRIPTION
The `allPackages` did not return all packages. This fixes it. Yes.