### PR TITLE
Fix: reverse package default sort order.

### DIFF
--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -11,7 +11,7 @@ func SortPackages(pkgs []PackageInfo, sortBy string) {
 
 	default: // date is the default sort
 		sort.Slice(pkgs, func(i, j int) bool {
-			return pkgs[i].Timestamp.Before(pkgs[j].Timestamp)
+			return pkgs[i].Timestamp.After(pkgs[j].Timestamp)
 		})
 	}
 }


### PR DESCRIPTION
This fixes issue #3  where the default sort is in chronological order rather than reverse chronological order.