### PR TITLE
Feature size filtering

### DIFF
--- a/cmd/yaylog/main.go
+++ b/cmd/yaylog/main.go
@@ -28,7 +28,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	packages = pkgdata.ConcurrentFilters(packages, cfg.DateFilter, cfg.ExplicitOnly, cfg.DependenciesOnly)
+	packages = pkgdata.ConcurrentFilters(packages, cfg.DateFilter, cfg.SizeFilter, cfg.ExplicitOnly, cfg.DependenciesOnly)
 	pkgdata.SortPackages(packages, cfg.SortBy)
 
 	if cfg.Count > 0 && !cfg.AllPackages && len(packages) > cfg.Count {

--- a/cmd/yaylog/main.go
+++ b/cmd/yaylog/main.go
@@ -9,7 +9,6 @@ import (
 )
 
 func main() {
-	// parse cli args (excluding the program name itself: os.Args[0])
 	cfg := config.ParseFlags(os.Args[1:])
 
 	// on -h or --help: print help and exit
@@ -18,11 +17,8 @@ func main() {
 		return
 	}
 
-	// fetch mock package data
 	packages, err := pkgdata.FetchPackages()
 	if err != nil {
-		// if something went wrong in fetching, log it and exit
-
 		fmt.Printf("Error fetching packages: %v\n", err)
 		os.Exit(1)
 	}
@@ -32,18 +28,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if cfg.ExplicitOnly {
-		packages = pkgdata.FilterExplicit(packages)
-	}
-
-	if cfg.DependenciesOnly {
-		packages = pkgdata.FilterDependencies(packages)
-	}
-
-	if !cfg.DateFilter.IsZero() {
-		packages = pkgdata.FilterByDate(packages, cfg.DateFilter)
-	}
-
+	packages = pkgdata.ConcurrentFilters(packages, cfg.DateFilter, cfg.ExplicitOnly, cfg.DependenciesOnly)
 	pkgdata.SortPackages(packages, cfg.SortBy)
 
 	if cfg.Count > 0 && !cfg.AllPackages && len(packages) > cfg.Count {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,10 +4,65 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/pflag"
 )
+
+const (
+	KB = 1024
+	MB = KB * KB
+	GB = MB * MB
+)
+
+func ParseSizeFilter(input string) (operator string, sizeInBytes int64, err error) {
+	re := regexp.MustCompile(`(?i)^(<|>)?(\d+(?:\.\d+)?)(KB|MB|GB|B)?$`)
+	matches := re.FindStringSubmatch(input)
+
+	// matches for input of ">2KB" should be an array of [">2KB", ">", "2", "KB"]
+
+	if len(matches) < 1 {
+		return "", 0, fmt.Errorf("invalid size filter format")
+	}
+
+	operator = matches[1]
+
+	if operator == "" {
+		operator = ">" // default to greater than
+		// TODO: implement greater/less than or equal to
+	}
+
+	value, err := strconv.ParseFloat(matches[2], 64) // parseFloat for fractional input e.g. ">2.5KB"
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid size value")
+	}
+
+	unit := strings.ToUpper(matches[3])
+
+	switch unit {
+	case "KB":
+		sizeInBytes = int64(value * KB)
+	case "MB":
+		sizeInBytes = int64(value * MB)
+	case "GB":
+		sizeInBytes = int64(value * GB)
+	case "B":
+		sizeInBytes = int64(value)
+	default:
+		return "", 0, fmt.Errorf("invalid size unit: %v", unit)
+	}
+
+	return operator, sizeInBytes, nil
+}
+
+type SizeFilter struct {
+	IsFilter    bool
+	SizeInBytes int64
+	Operator    string
+}
 
 type Config struct {
 	Count            int
@@ -16,10 +71,10 @@ type Config struct {
 	ExplicitOnly     bool
 	DependenciesOnly bool
 	DateFilter       time.Time
+	SizeFilter       SizeFilter
 	SortBy           string
 }
 
-// reads cli arguments and populates a Config
 func ParseFlags(args []string) Config {
 	var count int
 	var allPackages bool
@@ -27,16 +82,17 @@ func ParseFlags(args []string) Config {
 	var explicitOnly bool
 	var dependenciesOnly bool
 	var dateFilter string
+	var sizeFilter string
 	var sortBy string
 
-	// flags
-	// pflag.*VarP specifies a long name, a short name, and a default value
+	// pflag.*VarP specifies a long flag, a short flag, and a default value
 	pflag.IntVarP(&count, "number", "n", 20, "Number of packages to show")
 	pflag.BoolVarP(&allPackages, "all", "a", false, "Show all packages (ignores -n)")
 	pflag.BoolVarP(&showHelp, "help", "h", false, "Display help")
 	pflag.BoolVarP(&explicitOnly, "explicit", "e", false, "Show only explicitly installed packages")
 	pflag.BoolVarP(&dependenciesOnly, "dependencies", "d", false, "Show only packages installed as dependencies")
 	pflag.StringVar(&dateFilter, "date", "", "Filter packages installed on a specific date (YYYY-MM-DD)")
+	pflag.StringVar(&sizeFilter, "size", "", "Filter pacakges by size (e.g. >20MB, <1GB)")
 	pflag.StringVar(&sortBy, "sort", "date", "Sort by date/alphabetical/size")
 
 	if err := pflag.CommandLine.Parse(args); err != nil {
@@ -46,6 +102,22 @@ func ParseFlags(args []string) Config {
 
 	if allPackages {
 		count = 0
+	}
+
+	var sizeFilterParsed SizeFilter
+
+	if sizeFilter != "" {
+		var err error
+		sizeOperator, sizeInBytes, err := ParseSizeFilter(sizeFilter)
+		if err != nil {
+			log.Fatalf("Invalid size filter: %v\n", err)
+		}
+
+		sizeFilterParsed = SizeFilter{
+			IsFilter:    true,
+			SizeInBytes: sizeInBytes,
+			Operator:    sizeOperator,
+		}
 	}
 
 	var parsedDate time.Time
@@ -65,6 +137,7 @@ func ParseFlags(args []string) Config {
 		ExplicitOnly:     explicitOnly,
 		DependenciesOnly: dependenciesOnly,
 		DateFilter:       parsedDate,
+		SizeFilter:       sizeFilterParsed,
 		SortBy:           sortBy,
 	}
 }
@@ -79,5 +152,6 @@ Options:
   -d, --dependencies      Show only packages installed as dependencies
       --date <YYYY-MM-DD> Filter packages installed on a specific date
       --sort <mode>       Sort by date (default) or "alphabetical" or "size:asc"/"size:desc"
+      --size <filter>     Filter packages by size (e.g., >10MB, <1GB)
   -h, --help              Display this help message`)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,11 @@ func ParseFlags(args []string) Config {
 	pflag.StringVar(&dateFilter, "date", "", "Filter packages installed on a specific date (YYYY-MM-DD)")
 	pflag.StringVar(&sortBy, "sort", "date", "Sort by date/alphabetical/size")
 
+	if err := pflag.CommandLine.Parse(args); err != nil {
+		fmt.Printf("Error parsing flags: %v\n", err)
+		os.Exit(1)
+	}
+
 	if allPackages {
 		count = 0
 	}
@@ -51,12 +56,6 @@ func ParseFlags(args []string) Config {
 		if err != nil {
 			log.Fatalf("Invalid date format: %v\n", err)
 		}
-	}
-
-	// parse the flags in args
-	if err := pflag.CommandLine.Parse(args); err != nil {
-		fmt.Printf("Error parsing flags: %v\n", err)
-		os.Exit(1)
 	}
 
 	return Config{

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -9,8 +9,8 @@ import (
 
 const (
 	KB = 1024
-	MB = 1024 * KB
-	GB = 1024 * MB
+	MB = KB * KB
+	GB = MB * MB
 )
 
 // displays data in tab format

--- a/internal/pkgdata/filters.go
+++ b/internal/pkgdata/filters.go
@@ -1,8 +1,14 @@
 package pkgdata
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
-// TODO: combine functions to allow for mixed arguments
+type FilterCondition struct {
+	Condition bool
+	Filter    func([]PackageInfo) []PackageInfo
+}
 
 func FilterExplicit(pkgs []PackageInfo) []PackageInfo {
 	var explicitPackages []PackageInfo
@@ -39,4 +45,70 @@ func FilterByDate(pkgs []PackageInfo, date time.Time) []PackageInfo {
 	}
 
 	return filteredPackages
+}
+
+func applyConcurrentFilter(packages []PackageInfo, filterFunc func([]PackageInfo) []PackageInfo) []PackageInfo {
+	const chunkSize = 100
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	var filteredPackages []PackageInfo
+
+	for i := 0; i < len(packages); i += chunkSize {
+		endIdx := i + chunkSize
+
+		if endIdx > len(packages) {
+			endIdx = len(packages)
+		}
+
+		chunk := packages[i:endIdx]
+
+		wg.Add(1)
+
+		go func(chunk []PackageInfo) {
+			defer wg.Done()
+
+			filteredChunk := filterFunc(chunk)
+
+			mu.Lock()
+			filteredPackages = append(filteredPackages, filteredChunk...)
+			mu.Unlock()
+		}(chunk)
+	}
+
+	wg.Wait()
+
+	return filteredPackages
+}
+
+func ConcurrentFilters(packages []PackageInfo, dateFilter time.Time, explicitOnly bool, dependenciesOnly bool) []PackageInfo {
+	type FilterCondition struct {
+		Condition bool
+		Filter    func([]PackageInfo) []PackageInfo
+	}
+
+	filters := []FilterCondition{
+		{
+			Condition: explicitOnly,
+			Filter:    FilterExplicit,
+		},
+		{
+			Condition: dependenciesOnly,
+			Filter:    FilterDependencies,
+		},
+		{
+			Condition: !dateFilter.IsZero(),
+			Filter: func(pkgs []PackageInfo) []PackageInfo {
+				return FilterByDate(pkgs, dateFilter)
+			},
+		},
+	}
+
+	for _, f := range filters {
+		if f.Condition {
+			packages = applyConcurrentFilter(packages, f.Filter)
+		}
+	}
+
+	return packages
 }

--- a/yaylog.1
+++ b/yaylog.1
@@ -52,6 +52,21 @@ Sort results by the specified mode. Available modes:
 .B size:desc
 : Sort by size, in descending order.
 .TP
+.B \-\-size <filter>
+Filter results by size. Specify a comparison operator and size, such as:
+.IP
+.B >10MB
+: Show packages larger than 10MB.
+.IP
+.B <500KB
+: Show packages smaller than 500KB.
+.IP
+Size units can be specified as B (bytes), KB, MB, or GB. Filtering by size does not automatically sort the results; use
+.B \-\-sort size:asc
+or
+.B \-\-sort size:desc
+to explicitly sort by size if desired.
+.TP
 .B \-h
 Display help information.
 


### PR DESCRIPTION
 Addresses #12 

Introduces the `--size` option, allowing users to filter packages by their size. Examples:

- Show packages larger than 10MB:
  ```bash
  yaylog --size >10MB
  ```
- Show dependencies smaller than 500KB:
  ```bash
  yaylog -d --size <500KB
  ```
- Show the 10 largest explicitly installed packages:
  ```bash
  yaylog -en 10 --sort size:desc
  ```

Size units supported: `B`, `KB`, `MB`, `GB`. 

Sorting is not automatic; use `--sort size:asc` or `--sort size:desc` for ordered results.