### PR TITLE
Feature: Progress bar + concurrent sorting

### DIFF
--- a/cmd/yaylog/main.go
+++ b/cmd/yaylog/main.go
@@ -6,7 +6,25 @@ import (
 	"yaylog/internal/config"
 	"yaylog/internal/display"
 	"yaylog/internal/pkgdata"
+
+	"golang.org/x/term"
 )
+
+func startProgressListener(isInteractive bool, progressChan chan pkgdata.ProgressMessage) {
+	if isInteractive {
+		go func() {
+			for msg := range progressChan {
+				fmt.Printf("\r%-80s", fmt.Sprintf("[%s] %d%% - %s", msg.Phase, msg.Progress, msg.Description))
+			}
+		}()
+	} else {
+		go func() {
+			for range progressChan {
+				// discard messages in non-tty
+			}
+		}()
+	}
+}
 
 func main() {
 	cfg := config.ParseFlags(os.Args[1:])
@@ -28,7 +46,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	packages = pkgdata.ConcurrentFilters(packages, cfg.DateFilter, cfg.SizeFilter, cfg.ExplicitOnly, cfg.DependenciesOnly)
+	progressChan := make(chan pkgdata.ProgressMessage)
+	isInteractive := term.IsTerminal(int(os.Stdout.Fd()))
+	startProgressListener(isInteractive, progressChan)
+	packages = pkgdata.ConcurrentFilters(packages, progressChan, cfg.DateFilter, cfg.SizeFilter, cfg.ExplicitOnly, cfg.DependenciesOnly)
+	close(progressChan)
+
+	if isInteractive {
+		fmt.Println()
+	}
+
 	pkgdata.SortPackages(packages, cfg.SortBy)
 
 	if cfg.Count > 0 && !cfg.AllPackages && len(packages) > cfg.Count {

--- a/cmd/yaylog/main.go
+++ b/cmd/yaylog/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
+	"sync"
 	"yaylog/internal/config"
 	"yaylog/internal/display"
 	"yaylog/internal/pkgdata"
@@ -18,10 +18,11 @@ func main() {
 	validateConfig(cfg)
 
 	isInteractive := term.IsTerminal(int(os.Stdout.Fd()))
+	var wg sync.WaitGroup
 
 	pipeline := []PipelinePhase{
-		{"Filtering", applyFilters, isInteractive},
-		{"Sorting", sortPackages, isInteractive},
+		{"Filtering", applyFilters, isInteractive, &wg},
+		{"Sorting", sortPackages, isInteractive, &wg},
 	}
 
 	for _, phase := range pipeline {
@@ -38,8 +39,7 @@ func main() {
 		packages = packages[cutoffIdx:]
 	}
 
-	fmt.Print("\r" + strings.Repeat(" ", 80) + "\r")
-	display.PrintTable(packages)
+	display.Manager.PrintTable(packages)
 }
 
 func parseConfig() config.Config {

--- a/cmd/yaylog/pipeline_phase.go
+++ b/cmd/yaylog/pipeline_phase.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"yaylog/internal/config"
+	"yaylog/internal/pkgdata"
+)
+
+type (
+	ProgressReporter = pkgdata.ProgressReporter
+	ProgressMessage  = pkgdata.ProgressMessage
+	PackageInfo      = pkgdata.PackageInfo
+)
+
+type PipelinePhase struct {
+	Name          string
+	Operation     func(cfg config.Config, packages []PackageInfo, progressReporter ProgressReporter) []PackageInfo
+	IsInteractive bool
+}
+
+func (phase PipelinePhase) Run(cfg config.Config, packages []PackageInfo) []PackageInfo {
+	progressChan := phase.startProgress()
+	outputPackages := phase.Operation(cfg, packages, phase.reportProgress(progressChan))
+	phase.stopProgress(progressChan)
+
+	return outputPackages
+}
+
+func (phase PipelinePhase) reportProgress(progressChan chan ProgressMessage) ProgressReporter {
+	if progressChan == nil {
+		return ProgressReporter(func(current int, total int, phaseName string) {})
+	}
+
+	return ProgressReporter(func(current int, total int, phaseName string) {
+		progressChan <- ProgressMessage{
+			Phase:       phaseName,
+			Progress:    (current * 100) / total,
+			Description: fmt.Sprintf(("%s is in progress..."), phase.Name),
+		}
+	})
+}
+
+func (phase PipelinePhase) startProgress() chan ProgressMessage {
+	if !phase.IsInteractive {
+		return nil
+	}
+
+	progressChan := make(chan ProgressMessage)
+	go phase.displayProgress(progressChan)
+
+	return progressChan
+}
+
+func (phase PipelinePhase) stopProgress(progressChan chan ProgressMessage) {
+	if progressChan != nil {
+		close(progressChan)
+	}
+}
+
+func (phase PipelinePhase) displayProgress(progressChan chan ProgressMessage) {
+	for msg := range progressChan {
+		fmt.Print("\r" + strings.Repeat(" ", 80) + "\r")
+		progressMessageText := fmt.Sprintf("[%s] %d%% - %s", msg.Phase, msg.Progress, msg.Description)
+		fmt.Printf("%-80s", progressMessageText)
+
+		if msg.Progress == 100 {
+			// extra clear when done
+			fmt.Print("\r" + strings.Repeat(" ", 80) + "\r")
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,8 @@ module yaylog
 go 1.23.2
 
 require github.com/spf13/pflag v1.0.5
+
+require (
+	golang.org/x/sys v0.29.0 // indirect
+	golang.org/x/term v0.28.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module yaylog
 
 go 1.23.2
 
-require github.com/spf13/pflag v1.0.5
-
 require (
-	golang.org/x/sys v0.29.0 // indirect
-	golang.org/x/term v0.28.0 // indirect
+	github.com/spf13/pflag v1.0.5
+	golang.org/x/term v0.28.0
 )
+
+require golang.org/x/sys v0.29.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
+golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.28.0 h1:/Ts8HFuMR2E6IP/jlo7QVLZHggjKQbhu/7H0LJFr3Gg=
+golang.org/x/term v0.28.0/go.mod h1:Sw/lC2IAUZ92udQNf3WodGtn4k/XoLyZoh8v/8uiwek=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ const (
 	GB = MB * MB
 )
 
+// TODO: make this more readable
 func ParseSizeFilter(input string) (operator string, sizeInBytes int64, err error) {
 	re := regexp.MustCompile(`(?i)^(<|>)?(\d+(?:\.\d+)?)(KB|MB|GB|B)?$`)
 	matches := re.FindStringSubmatch(input)
@@ -85,7 +86,7 @@ func ParseFlags(args []string) Config {
 	var sizeFilter string
 	var sortBy string
 
-	// pflag.*VarP specifies a long flag, a short flag, and a default value
+	// TODO: make this more readable
 	pflag.IntVarP(&count, "number", "n", 20, "Number of packages to show")
 	pflag.BoolVarP(&allPackages, "all", "a", false, "Show all packages (ignores -n)")
 	pflag.BoolVarP(&showHelp, "help", "h", false, "Display help")

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -3,7 +3,6 @@ package display
 import (
 	"fmt"
 	"os"
-	"strings"
 	"sync"
 	"text/tabwriter"
 	"yaylog/internal/pkgdata"
@@ -34,6 +33,8 @@ func (o *OutputManager) PrintProgress(phase string, progress int, description st
 	defer o.mu.Unlock()
 
 	o.progressActive = true
+
+	fmt.Print("\r\033[K")
 	fmt.Printf("\r[%s] %d%% - %s", phase, progress, description)
 }
 
@@ -42,7 +43,7 @@ func (o *OutputManager) ClearProgress() {
 	defer o.mu.Unlock()
 
 	if o.progressActive {
-		fmt.Print("\r" + strings.Repeat(" ", 80) + "\r")
+		fmt.Print("\r\033[K")
 		o.progressActive = false
 	}
 }

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -3,6 +3,8 @@ package display
 import (
 	"fmt"
 	"os"
+	"strings"
+	"sync"
 	"text/tabwriter"
 	"yaylog/internal/pkgdata"
 )
@@ -13,8 +15,45 @@ const (
 	GB = MB * MB
 )
 
+type OutputManager struct {
+	mu             sync.Mutex
+	progressActive bool
+}
+
+var Manager = &OutputManager{}
+
+func (o *OutputManager) Write(msg string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	fmt.Print(msg)
+}
+
+func (o *OutputManager) PrintProgress(phase string, progress int, description string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	o.progressActive = true
+	fmt.Printf("\r[%s] %d%% - %s", phase, progress, description)
+}
+
+func (o *OutputManager) ClearProgress() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if o.progressActive {
+		fmt.Print("\r" + strings.Repeat(" ", 80) + "\r")
+		o.progressActive = false
+	}
+}
+
 // displays data in tab format
-func PrintTable(pkgs []pkgdata.PackageInfo) {
+func (o *OutputManager) PrintTable(pkgs []pkgdata.PackageInfo) {
+	o.ClearProgress()
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
 	fmt.Fprintln(w, "DATE\tNAME\tREASON\tSIZE")
 

--- a/internal/pkgdata/fetch.go
+++ b/internal/pkgdata/fetch.go
@@ -30,6 +30,7 @@ func FetchPackages() ([]PackageInfo, error) {
 
 		// check for correct field format, skip if not
 		if len(fields) != 4 {
+			fmt.Printf("Skipping malformed line: %q\n", line) // Debugging output
 			continue
 		}
 

--- a/internal/pkgdata/filters.go
+++ b/internal/pkgdata/filters.go
@@ -13,7 +13,7 @@ type FilterCondition struct {
 	PhaseName string
 }
 
-type ProgressReporter func(current, total int, phase string)
+type ProgressReporter func(current int, total int, phase string)
 
 func FilterExplicit(pkgs []PackageInfo) []PackageInfo {
 	var explicitPackages []PackageInfo

--- a/internal/pkgdata/filters.go
+++ b/internal/pkgdata/filters.go
@@ -13,8 +13,6 @@ type FilterCondition struct {
 	PhaseName string
 }
 
-type ProgressReporter func(current int, total int, phase string)
-
 func FilterExplicit(pkgs []PackageInfo) []PackageInfo {
 	var explicitPackages []PackageInfo
 

--- a/internal/pkgdata/progress.go
+++ b/internal/pkgdata/progress.go
@@ -1,0 +1,7 @@
+package pkgdata
+
+type ProgressMessage struct {
+	Phase       string
+	Progress    int
+	Description string
+}

--- a/internal/pkgdata/progress.go
+++ b/internal/pkgdata/progress.go
@@ -5,3 +5,5 @@ type ProgressMessage struct {
 	Progress    int
 	Description string
 }
+
+type ProgressReporter func(current int, total int, phase string)

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -1,27 +1,73 @@
 package pkgdata
 
-import "sort"
+import (
+	"fmt"
+	"sort"
+)
 
-func SortPackages(pkgs []PackageInfo, sortBy string) {
+type PackageComparator func(pkgs []PackageInfo, i int, j int) bool
+
+func alphabeticalComparator(pkgs []PackageInfo, i int, j int) bool {
+	return pkgs[i].Name < pkgs[j].Name
+}
+
+func dateComparator(pkgs []PackageInfo, i int, j int) bool {
+	return pkgs[i].Timestamp.Before(pkgs[j].Timestamp)
+}
+
+func sizeDecComparator(pkgs []PackageInfo, i int, j int) bool {
+	return pkgs[i].Size < pkgs[j].Size
+}
+
+func sizeAscComparator(pkgs []PackageInfo, i int, j int) bool {
+	return pkgs[i].Size > pkgs[j].Size
+}
+
+func getComparator(sortBy string) (PackageComparator, bool) {
 	switch sortBy {
 	case "alphabetical":
-		sort.Slice(pkgs, func(i, j int) bool {
-			return pkgs[i].Name < pkgs[j].Name
-		})
-
-	case "size:desc":
-		sort.Slice(pkgs, func(i, j int) bool {
-			return pkgs[i].Size > pkgs[j].Size
-		})
-
+		return alphabeticalComparator, true
+	case "date":
+		return dateComparator, true
+	case "size:dec":
+		return sizeDecComparator, true
 	case "size:asc":
-		sort.Slice(pkgs, func(i, j int) bool {
-			return pkgs[i].Size < pkgs[j].Size
-		})
-
-	default: // date is the default sort
-		sort.Slice(pkgs, func(i, j int) bool {
-			return pkgs[i].Timestamp.Before(pkgs[j].Timestamp)
-		})
+		return sizeAscComparator, true
+	default:
+		return nil, false
 	}
+}
+
+func sortWithProgress(pkgs []PackageInfo, comparator PackageComparator, phase string, reportProgress ProgressReporter) {
+	total := len(pkgs)
+	progressStep := max(1, total/10) // wait they finally added min() and max() to standard lib??
+
+	sort.SliceStable(pkgs, func(i int, j int) bool {
+		remainder := i % progressStep
+
+		if reportProgress != nil && remainder == 0 {
+			reportProgress(i, total, phase)
+		}
+
+		return comparator(pkgs, i, j)
+	})
+
+	if reportProgress != nil {
+		reportProgress(total, total, fmt.Sprintf("%s completed", phase))
+	}
+}
+
+func SortPackages(pkgs []PackageInfo, sortBy string, reportProgress ProgressReporter) []PackageInfo {
+	sortedPkgs := make([]PackageInfo, len(pkgs))
+	copy(sortedPkgs, pkgs)
+
+	comparator, valid := getComparator(sortBy)
+
+	if !valid {
+		panic(fmt.Sprintf("invalid sort mode: %s", sortBy))
+	}
+
+	sortWithProgress(sortedPkgs, comparator, "Sorting packages", reportProgress)
+
+	return sortedPkgs
 }

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -198,9 +198,9 @@ func SortPackages(pkgs []PackageInfo, sortBy string, reportProgress ProgressRepo
 
 	phase := "Sorting packages"
 
-	// if len(pkgs) < concurrentSortThreshold {
-	return sortNormally(pkgs, comparator, phase, reportProgress)
-	// }
+	if len(pkgs) < concurrentSortThreshold {
+		return sortNormally(pkgs, comparator, phase, reportProgress)
+	}
 
-	// return sortConcurrently(pkgs, comparator, phase, reportProgress)
+	return sortConcurrently(pkgs, comparator, phase, reportProgress)
 }

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -2,6 +2,7 @@ package pkgdata
 
 import (
 	"fmt"
+	"runtime"
 	"sort"
 	"sync"
 )
@@ -80,7 +81,9 @@ func sortConcurrently(
 		return nil
 	}
 
-	chunkSize := 100
+	numCPUs := runtime.NumCPU()
+	baseChunkSize := total / (2 * numCPUs)
+	chunkSize := max(100, baseChunkSize)
 
 	var mu sync.Mutex
 	var wg sync.WaitGroup
@@ -195,9 +198,9 @@ func SortPackages(pkgs []PackageInfo, sortBy string, reportProgress ProgressRepo
 
 	phase := "Sorting packages"
 
-	if len(pkgs) < concurrentSortThreshold {
-		return sortNormally(pkgs, comparator, phase, reportProgress)
-	}
+	// if len(pkgs) < concurrentSortThreshold {
+	return sortNormally(pkgs, comparator, phase, reportProgress)
+	// }
 
-	return sortConcurrently(pkgs, comparator, phase, reportProgress)
+	// return sortConcurrently(pkgs, comparator, phase, reportProgress)
 }

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -3,24 +3,27 @@ package pkgdata
 import (
 	"fmt"
 	"sort"
+	"sync"
 )
 
-type PackageComparator func(pkgs []PackageInfo, i int, j int) bool
+const concurrentSortThreshold = 2000
 
-func alphabeticalComparator(pkgs []PackageInfo, i int, j int) bool {
-	return pkgs[i].Name < pkgs[j].Name
+type PackageComparator func(a PackageInfo, b PackageInfo) bool
+
+func alphabeticalComparator(a PackageInfo, b PackageInfo) bool {
+	return a.Name < b.Name
 }
 
-func dateComparator(pkgs []PackageInfo, i int, j int) bool {
-	return pkgs[i].Timestamp.Before(pkgs[j].Timestamp)
+func dateComparator(a PackageInfo, b PackageInfo) bool {
+	return a.Timestamp.Before(b.Timestamp)
 }
 
-func sizeDecComparator(pkgs []PackageInfo, i int, j int) bool {
-	return pkgs[i].Size < pkgs[j].Size
+func sizeDecComparator(a PackageInfo, b PackageInfo) bool {
+	return a.Size < b.Size
 }
 
-func sizeAscComparator(pkgs []PackageInfo, i int, j int) bool {
-	return pkgs[i].Size > pkgs[j].Size
+func sizeAscComparator(a PackageInfo, b PackageInfo) bool {
+	return a.Size > b.Size
 }
 
 func getComparator(sortBy string) (PackageComparator, bool) {
@@ -38,36 +41,159 @@ func getComparator(sortBy string) (PackageComparator, bool) {
 	}
 }
 
-func sortWithProgress(pkgs []PackageInfo, comparator PackageComparator, phase string, reportProgress ProgressReporter) {
-	total := len(pkgs)
-	progressStep := max(1, total/10) // wait they finally added min() and max() to standard lib??
+func mergedSortedChunks(
+	leftChunk []PackageInfo,
+	rightChunk []PackageInfo,
+	comparator PackageComparator,
+) []PackageInfo {
+	capacity := len(leftChunk) + len(rightChunk)
+	result := make([]PackageInfo, 0, capacity)
+	i, j := 0, 0
 
-	sort.SliceStable(pkgs, func(i int, j int) bool {
-		remainder := i % progressStep
-
-		if reportProgress != nil && remainder == 0 {
-			reportProgress(i, total, phase)
+	for i < len(leftChunk) && j < len(rightChunk) {
+		if comparator(leftChunk[i], rightChunk[j]) {
+			result = append(result, leftChunk[i])
+			i++
+			continue
 		}
 
-		return comparator(pkgs, i, j)
-	})
+		result = append(result, rightChunk[j])
+		j++
+	}
+
+	// append remaining elements
+	result = append(result, leftChunk[i:]...)
+	result = append(result, rightChunk[j:]...)
+
+	return result
+}
+
+func sortConcurrently(
+	pkgs []PackageInfo,
+	comparator PackageComparator,
+	phase string,
+	reportProgress ProgressReporter,
+) []PackageInfo {
+	total := len(pkgs)
+
+	if total == 0 {
+		return nil
+	}
+
+	chunkSize := 100
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	numChunks := (total + chunkSize - 1) / chunkSize
+	chunks := make([][]PackageInfo, 0, numChunks) // pre-allocate
+
+	for chunkIdx := 0; chunkIdx < numChunks; chunkIdx++ {
+		startIdx := chunkIdx * chunkSize
+		endIdx := startIdx + chunkSize
+
+		if endIdx > total {
+			endIdx = total
+		}
+
+		chunk := make([]PackageInfo, endIdx-startIdx)
+		copy(chunk, pkgs[startIdx:endIdx]) // avoid mutating the original array
+
+		wg.Add(1)
+
+		// TODO: c is a bad name, maybe make this a seperate function
+		go func(c []PackageInfo) {
+			defer wg.Done()
+
+			sort.SliceStable(c, func(i int, j int) bool {
+				return comparator(c[i], c[j])
+			})
+
+			mu.Lock()
+			chunks = append(chunks, c)
+			mu.Unlock()
+
+			if reportProgress != nil {
+				currentProgress := (chunkIdx + 1) * 50 / numChunks // scale chunk sorting progress to 0%-50%
+				reportProgress(currentProgress, 100, fmt.Sprintf("%s - Sorted chunk %d/%d", phase, chunkIdx+1, numChunks))
+			}
+		}(chunk)
+	}
+
+	wg.Wait()
+
+	if reportProgress != nil {
+		// "halfway" there
+		reportProgress(50, 100, fmt.Sprintf("%s - Initial chunk sorting complete", phase))
+	}
+
+	mergeStep := 0
+
+	for len(chunks) > 1 {
+		var newChunks [][]PackageInfo
+
+		for i := 0; i < len(chunks); i += 2 {
+			if i+1 < len(chunks) {
+				mergedChunk := mergedSortedChunks(chunks[i], chunks[i+1], comparator)
+				newChunks = append(newChunks, mergedChunk)
+
+				continue
+			}
+			newChunks = append(newChunks, chunks[i]) // move odd chunk forward
+		}
+
+		chunks = newChunks
+
+		if reportProgress != nil {
+			mergeStep++
+			currentProgress := 50 + (mergeStep * 50 / (numChunks - 1)) // scale to 50%-100%
+			reportProgress(currentProgress, 100, fmt.Sprintf("%s - Merging step %d", phase, mergeStep))
+		}
+	}
 
 	if reportProgress != nil {
 		reportProgress(total, total, fmt.Sprintf("%s completed", phase))
 	}
+
+	if len(chunks) == 1 {
+		return chunks[0]
+	}
+
+	return nil
 }
 
-func SortPackages(pkgs []PackageInfo, sortBy string, reportProgress ProgressReporter) []PackageInfo {
+func sortNormally(
+	pkgs []PackageInfo,
+	comparator PackageComparator,
+	phase string,
+	reportProgress ProgressReporter,
+) []PackageInfo {
 	sortedPkgs := make([]PackageInfo, len(pkgs))
 	copy(sortedPkgs, pkgs)
 
+	reportProgress(0, 100, fmt.Sprintf("%s - normally", phase))
+
+	sort.SliceStable(sortedPkgs, func(i int, j int) bool {
+		return comparator(sortedPkgs[i], sortedPkgs[j])
+	})
+
+	reportProgress(100, 100, fmt.Sprintf("%s completed", phase))
+
+	return sortedPkgs
+}
+
+func SortPackages(pkgs []PackageInfo, sortBy string, reportProgress ProgressReporter) []PackageInfo {
 	comparator, valid := getComparator(sortBy)
 
 	if !valid {
 		panic(fmt.Sprintf("invalid sort mode: %s", sortBy))
 	}
 
-	sortWithProgress(sortedPkgs, comparator, "Sorting packages", reportProgress)
+	phase := "Sorting packages"
 
-	return sortedPkgs
+	if len(pkgs) < concurrentSortThreshold {
+		return sortNormally(pkgs, comparator, phase, reportProgress)
+	}
+
+	return sortConcurrently(pkgs, comparator, phase, reportProgress)
 }

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 )
 
-const concurrentSortThreshold = 2000
+const concurrentSortThreshold = 500
 
 type PackageComparator func(a PackageInfo, b PackageInfo) bool
 
@@ -171,13 +171,17 @@ func sortNormally(
 	sortedPkgs := make([]PackageInfo, len(pkgs))
 	copy(sortedPkgs, pkgs)
 
-	reportProgress(0, 100, fmt.Sprintf("%s - normally", phase))
+	if reportProgress != nil {
+		reportProgress(0, 100, fmt.Sprintf("%s - normally", phase))
+	}
 
 	sort.SliceStable(sortedPkgs, func(i int, j int) bool {
 		return comparator(sortedPkgs[i], sortedPkgs[j])
 	})
 
-	reportProgress(100, 100, fmt.Sprintf("%s completed", phase))
+	if reportProgress != nil {
+		reportProgress(100, 100, fmt.Sprintf("%s completed", phase))
+	}
 
 	return sortedPkgs
 }


### PR DESCRIPTION
For installed packages over 500, concurrent sorting is used. The size of chunks depends on the CPU cores/threads. 

Progress bar for interactive terminals as well! No progress bar if you are piping it `yaylog` into another command. 

Big refactor too!