### PR TITLE
Fix: sorting mode reversed + graceful invalid mode

### DIFF
--- a/cmd/yaylog/main.go
+++ b/cmd/yaylog/main.go
@@ -110,5 +110,11 @@ func sortPackages(
 	packages []pkgdata.PackageInfo,
 	reportProgress pkgdata.ProgressReporter,
 ) []pkgdata.PackageInfo {
-	return pkgdata.SortPackages(packages, cfg.SortBy, reportProgress)
+	sortedPackages, err := pkgdata.SortPackages(packages, cfg.SortBy, reportProgress)
+	if err != nil {
+		fmt.Printf("Error: %v \n", err)
+		os.Exit(1)
+	}
+
+	return sortedPackages
 }

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -20,11 +20,11 @@ func dateComparator(a PackageInfo, b PackageInfo) bool {
 }
 
 func sizeDecComparator(a PackageInfo, b PackageInfo) bool {
-	return a.Size < b.Size
+	return a.Size > b.Size
 }
 
 func sizeAscComparator(a PackageInfo, b PackageInfo) bool {
-	return a.Size > b.Size
+	return a.Size < b.Size
 }
 
 func getComparator(sortBy string) (PackageComparator, bool) {
@@ -33,7 +33,7 @@ func getComparator(sortBy string) (PackageComparator, bool) {
 		return alphabeticalComparator, true
 	case "date":
 		return dateComparator, true
-	case "size:dec":
+	case "size:desc":
 		return sizeDecComparator, true
 	case "size:asc":
 		return sizeAscComparator, true
@@ -189,18 +189,18 @@ func sortNormally(
 	return sortedPkgs
 }
 
-func SortPackages(pkgs []PackageInfo, sortBy string, reportProgress ProgressReporter) []PackageInfo {
+func SortPackages(pkgs []PackageInfo, sortBy string, reportProgress ProgressReporter) ([]PackageInfo, error) {
 	comparator, valid := getComparator(sortBy)
 
 	if !valid {
-		panic(fmt.Sprintf("invalid sort mode: %s", sortBy))
+		return nil, fmt.Errorf("invalid sort mode: %s", sortBy)
 	}
 
 	phase := "Sorting packages"
 
 	if len(pkgs) < concurrentSortThreshold {
-		return sortNormally(pkgs, comparator, phase, reportProgress)
+		return sortNormally(pkgs, comparator, phase, reportProgress), nil
 	}
 
-	return sortConcurrently(pkgs, comparator, phase, reportProgress)
+	return sortConcurrently(pkgs, comparator, phase, reportProgress), nil
 }


### PR DESCRIPTION
Fixed #16 and also now allowing an invalid sort mode to exit gracefully rather than panicking.