### PR TITLE
Feature: Remove expac as a dependency

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -112,7 +112,6 @@ func ParseFlags(args []string) Config {
 	var sizeFilterParsed SizeFilter
 
 	if sizeFilter != "" {
-		var err error
 		sizeOperator, sizeInBytes, err := ParseSizeFilter(sizeFilter)
 		if err != nil {
 			log.Fatalf("Invalid size filter: %v\n", err)


### PR DESCRIPTION
By removing `expac` as a dependency and doing the data extraction natively, we've gained a 2x performance gain in all scenarios... even over just using `expac` without piping it to other bash utils. 

Now we're faster than all the scripts that use `expac`. Nice.

Addresses #24 