### PR TITLE
Feature: Add --no-progress flag to force disable progress bar outside non-interactive environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ yaylog [options]
   - `date` (default): sort by installation date
   - `alphabetical`: sort alphabetically by package name
   - `size:asc` / `size:desc`: sort by package size on disk; ascending or descending, respectively
+- `--full-timestamp`: display the full timestamp (date and time) of package installations instead of just the date
+- `--no-progress`: force no progress bar outside of non-interactive environments
 - `-h`: print help info
 
 ### examples

--- a/cmd/yaylog/main.go
+++ b/cmd/yaylog/main.go
@@ -17,7 +17,7 @@ func main() {
 
 	validateConfig(cfg)
 
-	isInteractive := term.IsTerminal(int(os.Stdout.Fd()))
+	isInteractive := term.IsTerminal(int(os.Stdout.Fd())) || cfg.ShowProgress
 	var wg sync.WaitGroup
 
 	pipeline := []PipelinePhase{

--- a/cmd/yaylog/main.go
+++ b/cmd/yaylog/main.go
@@ -17,7 +17,7 @@ func main() {
 
 	validateConfig(cfg)
 
-	isInteractive := term.IsTerminal(int(os.Stdout.Fd())) || cfg.ShowProgress
+	isInteractive := term.IsTerminal(int(os.Stdout.Fd())) && cfg.ShowProgress
 	var wg sync.WaitGroup
 
 	pipeline := []PipelinePhase{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,7 @@ type Config struct {
 	AllPackages       bool
 	ShowHelp          bool
 	ShowFullTimestamp bool
+	ShowProgress      bool
 	ExplicitOnly      bool
 	DependenciesOnly  bool
 	DateFilter        time.Time
@@ -82,6 +83,7 @@ func ParseFlags(args []string) Config {
 	var allPackages bool
 	var showHelp bool
 	var showFullTimestamp bool
+	var disableProgress bool
 	var explicitOnly bool
 	var dependenciesOnly bool
 	var dateFilter string
@@ -93,6 +95,7 @@ func ParseFlags(args []string) Config {
 	pflag.BoolVarP(&allPackages, "all", "a", false, "Show all packages (ignores -n)")
 	pflag.BoolVarP(&showHelp, "help", "h", false, "Display help")
 	pflag.BoolVarP(&showFullTimestamp, "full-timestamp", "", false, "Show full timestamp instead of just the date")
+	pflag.BoolVarP(&disableProgress, "no-progress", "", false, "Force suppress progress output")
 	pflag.BoolVarP(&explicitOnly, "explicit", "e", false, "Show only explicitly installed packages")
 	pflag.BoolVarP(&dependenciesOnly, "dependencies", "d", false, "Show only packages installed as dependencies")
 
@@ -139,6 +142,7 @@ func ParseFlags(args []string) Config {
 		AllPackages:       allPackages,
 		ShowHelp:          showHelp,
 		ShowFullTimestamp: showFullTimestamp,
+		ShowProgress:      !disableProgress,
 		ExplicitOnly:      explicitOnly,
 		DependenciesOnly:  dependenciesOnly,
 		DateFilter:        parsedDate,

--- a/yaylog.1
+++ b/yaylog.1
@@ -71,6 +71,9 @@ Sort results by the specified mode. Available modes:
 .B \-\-full-timestamp
 Display the full timestamp (date and time) of package installations instead of just the date.
 .TP
+.B \-\-no-progress 
+Force disable progress bar outside non-interactive environments
+.TP
 .B \-h, \-\-help
 Display help information.
 


### PR DESCRIPTION
The progress bar is already disabled in non-TTY environments but this ensures there is no progress bar if no progress bar is still desired. 