### PR TITLE
Feature: Filter by name

### DIFF
--- a/cmd/yaylog/main.go
+++ b/cmd/yaylog/main.go
@@ -107,6 +107,13 @@ func applyFilters(
 			},
 			PhaseName: "Filtering by size",
 		},
+		{
+			Condition: len(cfg.NameFilter) > 0,
+			Filter: func(pkg pkgdata.PackageInfo) bool {
+				return pkgdata.FilterByName(pkg, cfg.NameFilter)
+			},
+			PhaseName: "Filtering by name",
+		},
 	}
 
 	return pkgdata.ApplyFilters(packages, filters, reportProgress)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	DependenciesOnly  bool
 	DateFilter        time.Time
 	SizeFilter        SizeFilter
+	NameFilter        string
 	SortBy            string
 	OptionalColumns   []string
 }
@@ -47,6 +48,7 @@ func ParseFlags(args []string) (Config, error) {
 	var dependenciesOnly bool
 	var dateFilter string
 	var sizeFilter string
+	var nameFilter string
 	var sortBy string
 
 	pflag.IntVarP(&count, "number", "n", 20, "Number of packages to show")
@@ -61,6 +63,7 @@ func ParseFlags(args []string) (Config, error) {
 
 	pflag.StringVar(&dateFilter, "date", "", "Filter packages installed on a specific date (YYYY-MM-DD)")
 	pflag.StringVar(&sizeFilter, "size", "", "Filter packages by size, must be in quotes (e.g. \">20MB\", \"<1GB\")")
+	pflag.StringVar(&nameFilter, "name", "", "Filter packages by name (or similar name)")
 	pflag.StringVar(&sortBy, "sort", "date", "Sort packages by: 'date', 'alphabetical', 'size:desc', 'size:asc'")
 
 	if err := pflag.CommandLine.Parse(args); err != nil {
@@ -91,6 +94,7 @@ func ParseFlags(args []string) (Config, error) {
 		DependenciesOnly:  dependenciesOnly,
 		DateFilter:        dateFilterParsed,
 		SizeFilter:        sizeFilterParsed,
+		NameFilter:        nameFilter,
 		SortBy:            sortBy,
 		OptionalColumns:   parseOptionalColumns(showVersion),
 	}, nil

--- a/internal/pkgdata/filters.go
+++ b/internal/pkgdata/filters.go
@@ -1,6 +1,7 @@
 package pkgdata
 
 import (
+	"strings"
 	"time"
 )
 
@@ -34,6 +35,10 @@ func FilterBySize(pkg PackageInfo, operator string, sizeInBytes int64) bool {
 	default:
 		return false
 	}
+}
+
+func FilterByName(pkg PackageInfo, searchTerm string) bool {
+	return strings.Contains(pkg.Name, searchTerm)
 }
 
 func ApplyFilters(pkgs []PackageInfo, filters []FilterCondition, reportProgress ProgressReporter) []PackageInfo {


### PR DESCRIPTION
Filter by if the package name contains the search term.

```bash
> yaylog --name vim
DATE        NAME                REASON      SIZE                                  
2024-12-18  tree-sitter-vim     dependency  1.13 MB
2024-12-18  tree-sitter-vimdoc  dependency  208.92 KB
2025-02-11  neovim              explicit    27.85 MB
2025-02-13  vim-runtime         dependency  37.55 MB
2025-02-13  vim                 explicit    5.08 MB
```