### PR TITLE
Feature: Date range filter

### DIFF
--- a/cmd/yaylog/pipeline_phase.go
+++ b/cmd/yaylog/pipeline_phase.go
@@ -31,7 +31,7 @@ func (phase PipelinePhase) Run(cfg config.Config, packages []PackageInfo) []Pack
 
 func (phase PipelinePhase) reportProgress(progressChan chan ProgressMessage) ProgressReporter {
 	if progressChan == nil {
-		return ProgressReporter(func(current int, total int, phaseName string) {})
+		return ProgressReporter(func(_ int, _ int, _ string) {})
 	}
 
 	return ProgressReporter(func(current int, total int, phaseName string) {

--- a/internal/pkgdata/fetch.go
+++ b/internal/pkgdata/fetch.go
@@ -146,12 +146,14 @@ func applyField(pkg *PackageInfo, field string, value string) error {
 	switch field {
 	case fieldName:
 		pkg.Name = value
+
 	case fieldReason:
 		if value == "1" {
 			pkg.Reason = "dependency"
 		} else {
 			pkg.Reason = "explicit"
 		}
+
 	case fieldInstallDate:
 		installDate, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
@@ -159,8 +161,10 @@ func applyField(pkg *PackageInfo, field string, value string) error {
 		}
 
 		pkg.Timestamp = time.Unix(installDate, 0)
+
 	case fieldVersion:
 		pkg.Version = value
+
 	case fieldSize:
 		size, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
@@ -168,6 +172,7 @@ func applyField(pkg *PackageInfo, field string, value string) error {
 		}
 
 		pkg.Size = size
+
 	default:
 		// ignore unknown fields
 	}

--- a/internal/pkgdata/filters.go
+++ b/internal/pkgdata/filters.go
@@ -26,6 +26,11 @@ func FilterByDate(pkg PackageInfo, date time.Time) bool {
 	return pkg.Timestamp.Year() == date.Year() && pkg.Timestamp.YearDay() == date.YearDay()
 }
 
+// inclusive
+func FilterByDateRange(pkg PackageInfo, startDate time.Time, endDate time.Time) bool {
+	return !(pkg.Timestamp.Before(startDate) || pkg.Timestamp.After(endDate))
+}
+
 func FilterBySize(pkg PackageInfo, operator string, sizeInBytes int64) bool {
 	switch operator {
 	case ">":


### PR DESCRIPTION
The date range filter is used with:
```bash
> yaylog --date 2025-02-11:2025-02-13
DATE        NAME                    REASON      SIZE
2025-02-11  tree-sitter-c           dependency  655.65 KB
2025-02-11  unibilium               dependency  215.67 KB
2025-02-11  neovim                  explicit    27.85 MB
2025-02-11  oniguruma               dependency  969.03 KB
2025-02-11  poppler                 dependency  7.09 MB
2025-02-11  poppler-glib            dependency  3.24 MB
2025-02-11  procps-ng               dependency  3.20 MB
2025-02-11  sudo                    explicit    8.72 MB
2025-02-11  systemd-sysvcompat      dependency  2.65 KB
2025-02-11  yazi                    explicit    14.89 MB
2025-02-11  zsh-completions         explicit    1.34 MB
2025-02-11  zsh                     explicit    8.33 MB
2025-02-11  golangci-lint-bin       explicit    28.29 MB
2025-02-12  perl-mime-charset       dependency  52.85 KB
2025-02-12  perl-unicode-linebreak  dependency  248.76 KB
2025-02-12  perl-yaml-tiny          dependency  48.70 KB
2025-02-12  po4a                    dependency  3.60 MB
2025-02-13  gpm                     dependency  848.57 KB
2025-02-13  vim-runtime             dependency  37.55 MB
2025-02-13  vim                     explicit    5.08 MB
```

- `date` is for an exact date
- `date:date` is for an inclusive range
- `date:` is for a range from the specified date to an implied current date/moment
- `:date` is for a range from the implied beginning of time to the specified date