### PR TITLE
Fix: No date filter flag

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,7 +108,7 @@ func ParseFlags(args []string) (Config, error) {
 
 func parseDateFilter(dateFilterInput string) (DateFilter, error) {
 	if dateFilterInput == "" {
-		return DateFilter{}, fmt.Errorf("No date specified for --date flag")
+		return DateFilter{}, nil
 	}
 
 	dateParts := strings.Split(dateFilterInput, ":")


### PR DESCRIPTION
This fixes running yaylog without date arguments.

```
> yaylog
Error parsing arguments: No date specified for --date flag
```