### PR TITLE
Feature: Add provides column

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ this package is compatible with the following distributions:
 
 ## features
 
-- list installed packages with timestamps
+- list installed packages with date/timestamps, dependencies, size on disk, and version
 - display package versions 
 - filter results by explicitly installed packages
 - filter results by packages installed as dependencies
@@ -52,13 +52,14 @@ because yay is my preferred AUR helper and the name has a good flow.
 - [x] filter by date range
 - [x] concurrent file reading (2x speed boost)
 - [x] remove expac as a dependency (3x speed boost)
+- [x] list provides packages
 - [x] optional full timestamp 
 - [x] add CI to release binaries
 - [x] remove go as a dependency
 - [x] filter by range of size on disk
 - [x] user defined columns
 - [x] list dependencies of each package
-- [ ] list packages that depend on each package
+- [ ] list reverse-dependencies of each package (required-by field)
 
 ## installation
 
@@ -137,6 +138,7 @@ yaylog [options]
 - `size` - package size on disk
 - `version` - installed package version
 - `depends` - list of dependencies (output can be long)
+- `provides` - list of alternative package names or shared libraries provided by package (output can be long)
 
 ### tips & tricks
 
@@ -153,7 +155,7 @@ are treated as separate parameters.
   yaylog -en 15
   ```
 
-- the `depends` column output can be lengthy. to improve readability, pipe the output to `less`:
+- the `depends` and `provides` columns output can be lengthy. to improve readability, pipe the output to `less`:
   ```bash
   yaylog --columns name,depends | less
   ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -245,7 +245,7 @@ func parseColumns(columnsInput string, addColumnsInput string) ([]string, error)
 		specifiedColumnsRaw = addColumnsInput
 		fallthrough
 	default:
-		columns = []string{consts.DATE, consts.NAME, consts.REASON, consts.SIZE}
+		columns = consts.DefaultColumns
 	}
 
 	specifiedColumns, err := validateColumns(strings.ToLower(specifiedColumnsRaw))
@@ -268,12 +268,13 @@ func validateColumns(columnInput string) ([]string, error) {
 	}
 
 	validColumns := map[string]bool{
-		consts.DATE:    true,
-		consts.NAME:    true,
-		consts.REASON:  true,
-		consts.SIZE:    true,
-		consts.VERSION: true,
-		consts.DEPENDS: true,
+		consts.Date:     true,
+		consts.Name:     true,
+		consts.Reason:   true,
+		consts.Size:     true,
+		consts.Version:  true,
+		consts.Depends:  true,
+		consts.Provides: true,
 	}
 
 	var columns []string
@@ -330,6 +331,7 @@ func PrintHelp() {
 	fmt.Println("  size      - Package size on disk")
 	fmt.Println("  version   - Installed package version")
 	fmt.Println("  depends   - List of dependencies (output can be long)")
+	fmt.Println("  provides  - List of alternative package names or shared libraries provided by package (output can be long)")
 
 	fmt.Println("\nCaveat:")
 	fmt.Println("  The 'depends' column output can be lengthy. It's recommended to use `less` for better readability:")

--- a/internal/consts/columns.go
+++ b/internal/consts/columns.go
@@ -1,12 +1,13 @@
 package consts
 
 const (
-	DATE    = "date"
-	NAME    = "name"
-	REASON  = "reason"
-	SIZE    = "size"
-	VERSION = "version"
-	DEPENDS = "depends"
+	Date     = "date"
+	Name     = "name"
+	Reason   = "reason"
+	Size     = "size"
+	Version  = "version"
+	Depends  = "depends"
+	Provides = "provides"
 )
 
-var DefaultColumns = []string{DATE, NAME, REASON, SIZE}
+var DefaultColumns = []string{Date, Name, Reason, Size}

--- a/internal/display/columns.go
+++ b/internal/display/columns.go
@@ -19,21 +19,24 @@ type Column struct {
 }
 
 var allColumns = map[string]Column{
-	consts.DATE: {"DATE", formatDate},
-	consts.NAME: {"NAME", func(pkg PackageInfo, _ displayContext) string {
+	consts.Date: {"DATE", formatDate},
+	consts.Name: {"NAME", func(pkg PackageInfo, _ displayContext) string {
 		return pkg.Name
 	}},
-	consts.VERSION: {"VERSION", func(pkg PackageInfo, _ displayContext) string {
+	consts.Version: {"VERSION", func(pkg PackageInfo, _ displayContext) string {
 		return pkg.Version
 	}},
-	consts.REASON: {"REASON", func(pkg PackageInfo, _ displayContext) string {
+	consts.Reason: {"REASON", func(pkg PackageInfo, _ displayContext) string {
 		return pkg.Reason
 	}},
-	consts.SIZE: {"SIZE", func(pkg PackageInfo, _ displayContext) string {
+	consts.Size: {"SIZE", func(pkg PackageInfo, _ displayContext) string {
 		return formatSize(pkg.Size)
 	}},
-	consts.DEPENDS: {"DEPENDS", func(pkg PackageInfo, _ displayContext) string {
-		return formatDependencies(pkg.Depends)
+	consts.Depends: {"DEPENDS", func(pkg PackageInfo, _ displayContext) string {
+		return formatPackageList(pkg.Depends)
+	}},
+	consts.Provides: {"PROVIDES", func(pkg PackageInfo, _ displayContext) string {
+		return formatPackageList(pkg.Provides)
 	}},
 }
 
@@ -41,11 +44,11 @@ func formatDate(pkg PackageInfo, ctx displayContext) string {
 	return pkg.Timestamp.Format(ctx.DateFormat)
 }
 
-func formatDependencies(depends []string) string {
-	if len(depends) == 0 {
+func formatPackageList(packages []string) string {
+	if len(packages) == 0 {
 		return "-"
 	}
-	return strings.Join(depends, ", ")
+	return strings.Join(packages, ", ")
 }
 
 func GetColumnByName(name string) Column {

--- a/internal/pkgdata/fetch.go
+++ b/internal/pkgdata/fetch.go
@@ -20,6 +20,7 @@ const (
 	fieldReason      = "%REASON%"
 	fieldVersion     = "%VERSION%"
 	fieldDepends     = "%DEPENDS%"
+	fieldProvides    = "%PROVIDES%"
 	pacmanDbPath     = "/var/lib/pacman/local"
 )
 
@@ -120,7 +121,7 @@ func parseDescFile(descPath string) (PackageInfo, error) {
 		line := strings.TrimSpace(scanner.Text())
 
 		switch line {
-		case fieldName, fieldInstallDate, fieldSize, fieldReason, fieldVersion, fieldDepends:
+		case fieldName, fieldInstallDate, fieldSize, fieldReason, fieldVersion, fieldDepends, fieldProvides:
 			currentField = line
 		case "":
 			currentField = "" // reset if line is blank
@@ -176,6 +177,9 @@ func applyField(pkg *PackageInfo, field string, value string) error {
 	case fieldDepends:
 		// use this if we ever need to separate the package name from its dependencies re := regexp.MustCompile(`^([^<>=]+)`)
 		pkg.Depends = append(pkg.Depends, value)
+
+	case fieldProvides:
+		pkg.Provides = append(pkg.Provides, value)
 
 	default:
 		// ignore unknown fields

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -10,4 +10,5 @@ type PackageInfo struct {
 	Size      int64  // package size in bytes
 	Version   string // current installed version
 	Depends   []string
+	Provides  []string
 }

--- a/yaylog.1
+++ b/yaylog.1
@@ -116,6 +116,9 @@ Available columns:
 .IP
 .B depends
 : List of dependencies (output can be long).
+.IP
+.B provides
+: List of alternative package names or shared libraries provided by package (output can be long).
 .TP
 .B \-\-add-columns <list>
 Add additional columns to the default display without overriding them.


### PR DESCRIPTION
Users can now list of alternative package names or shared libraries provided by package.

Usage:
```bash
yaylog --add-columns provides
```

or

```bash
yaylog --columns name,provides
```