### PR TITLE
Feature: all-columns option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ despite the name, it's not limited to `yay` and works with any package manager t
 this package is compatible with the following distributions:
  - arch linux
  - manjaro
+ - steamOS
  - garuda linux
  - endeavourOS
+ - artix linux
  - the 50 other arch-based distros, as long as it has pacman installed 
 
 ## features
@@ -139,6 +141,7 @@ yaylog [options]
   - `size:asc` / `size:desc` - sort by package size (ascending or descending)
 - `--columns <list>`: comma-separated list of columns to display (overrides defaults)
 - `--add-columns <list>`: comma-separated list of columns to add to defaults
+- `--all-columns`: show all available columns in the output (overrides defaults)
 - `--full-timestamp`: display the full timestamp (date and time) of package installations instead of just the date
 - `--json`: output results in JSON format (overrides table output and `--full-timestamp`)
 - `--no-progress`: force no progress bar outside of non-interactive environments
@@ -288,7 +291,7 @@ are treated as separate parameters.
    ```
 18. save all explicitly installed packages to a JSON file:
    ```bash
-   yaylog --json -e > explicit-packages.json
+   yaylog -ae --json > explicit-packages.json
    ```
 19. output all packages sorted by size (descending) in JSON:
    ```bash
@@ -297,4 +300,12 @@ are treated as separate parameters.
 20. output JSON with specific columns:
    ```bash
    yaylog --json --columns name,version,size
+   ```
+21. show all available package details:
+   ```bash
+   yaylog --all-columns
+   ```
+22. output all packages with all columns/fields in JSON format:
+   ```bash
+   yaylog -a --all-columns --json
    ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ because yay is my preferred AUR helper and the name has a good flow.
 - [ ] no-headers option
 - [ ] provides filter
 - [ ] depends filter
-- [ ] all-columns option
+- [x] all-columns option
 - [ ] required-by filter
 
 ## installation

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 func ParseFlags(args []string) (Config, error) {
 	var count int
 	var allPackages bool
+	var hasAllColumns bool
 	var showHelp bool
 	var outputJson bool
 	var showFullTimestamp bool
@@ -60,6 +61,7 @@ func ParseFlags(args []string) (Config, error) {
 	pflag.IntVarP(&count, "number", "n", 20, "Number of packages to show")
 
 	pflag.BoolVarP(&allPackages, "all", "a", false, "Show all packages (ignores -n)")
+	pflag.BoolVarP(&hasAllColumns, "all-columns", "", false, "Show all columns/fields in output")
 	pflag.BoolVarP(&showHelp, "help", "h", false, "Display help")
 	pflag.BoolVarP(&outputJson, "json", "", false, "Output results in JSON format")
 	pflag.BoolVarP(&showFullTimestamp, "full-timestamp", "", false, "Show full timestamp instead of just the date")
@@ -92,7 +94,7 @@ func ParseFlags(args []string) (Config, error) {
 		return Config{}, err
 	}
 
-	columnsParsed, err := parseColumns(columnsInput, addColumnsInput)
+	columnsParsed, err := parseColumns(columnsInput, addColumnsInput, hasAllColumns)
 	if err != nil {
 		return Config{}, err
 	}
@@ -234,9 +236,13 @@ func parseSizeInBytes(valueInput string, unitInput string) (sizeInBytes int64, e
 	return sizeInBytes, nil
 }
 
-func parseColumns(columnsInput string, addColumnsInput string) ([]string, error) {
+func parseColumns(columnsInput string, addColumnsInput string, hasAllColumns bool) ([]string, error) {
 	if columnsInput != "" && addColumnsInput != "" {
 		return nil, fmt.Errorf("cannot use --columns and --add-columns together. Use --columns to fully define the columns you want")
+	}
+
+	if hasAllColumns {
+		return consts.ValidColumns, nil
 	}
 
 	var specifiedColumnsRaw string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,7 +61,7 @@ func ParseFlags(args []string) (Config, error) {
 	pflag.IntVarP(&count, "number", "n", 20, "Number of packages to show")
 
 	pflag.BoolVarP(&allPackages, "all", "a", false, "Show all packages (ignores -n)")
-	pflag.BoolVarP(&hasAllColumns, "all-columns", "", false, "Show all columns/fields in output")
+	pflag.BoolVarP(&hasAllColumns, "all-columns", "", false, "Show all available columns/fields in the output (overrides defaults)")
 	pflag.BoolVarP(&showHelp, "help", "h", false, "Display help")
 	pflag.BoolVarP(&outputJson, "json", "", false, "Output results in JSON format")
 	pflag.BoolVarP(&showFullTimestamp, "full-timestamp", "", false, "Show full timestamp instead of just the date")

--- a/yaylog.1
+++ b/yaylog.1
@@ -4,7 +4,7 @@
 yaylog \- List and filter installed packages on Arch-based systems.
 .SH SYNOPSIS
 .B yaylog
-.RI [ \-n | \-\-number <number> ] [ \-e | \-\-explicit ] [ \-a | \-\-all ] [ \-d | \-\-dependencies ] [ \-\-date <filter> ] [ \-\-size <filter> ] [ \-\-name <search-term> ] [ \-\-sort <mode> ] [ \-\-columns <list> ] [ \-\-add-columns <list> ] [ \-\-json ] [ \-\-full-timestamp ] [ \-\-no-progress ] [ \-h | \-\-help ]
+.RI [ \-n | \-\-number <number> ] [ \-e | \-\-explicit ] [ \-a | \-\-all ] [ \-d | \-\-dependencies ] [ \-\-date <filter> ] [ \-\-size <filter> ] [ \-\-name <search-term> ] [ \-\-sort <mode> ] [ \-\-columns <list> ] [ \-\-add-columns <list> ] [ \-\-all-columns ] [ \-\-json ] [ \-\-full-timestamp ] [ \-\-no-progress ] [ \-h | \-\-help ]
 .SH DESCRIPTION
 .B yaylog
 is a standalone CLI utility for Arch and Arch-based Linux distributions to list and filter installed packages. It works with any package manager that uses ALPM,
@@ -118,13 +118,16 @@ Available columns:
 : List of dependencies (output can be long).
 .IP
 .B required-by
-: List of packages required by the package and are dependent on it (output can be long)
+: List of packages required by the package and are dependent on it (output can be long).
 .IP
 .B provides
 : List of alternative package names or shared libraries provided by package (output can be long).
 .TP
 .B \-\-add-columns <list>
 Add additional columns to the default display without overriding them.
+.TP
+.B \-\-all-columns
+Show all available columns in the output (overrides defaults).
 .TP
 .B \-\-json
 Output results in JSON format instead of a table. Overrides
@@ -165,42 +168,6 @@ Force disable progress bar outside non-interactive environments.
 .TP
 .B \-h, \-\-help
 Display help information.
-
-.SH ADDITIONAL NOTES
-.TP
-- All options that take an argument can also be used in the `--<flag>=<argument>` format.
-For example:
-.PP
-.EX
-yaylog --size=100MB:1GB --date=:2024-06-30
-yaylog --name="gtk" --sort=alphabetical
-.EE
-.TP
-- Boolean flags can be explicitly set using `--<flag>=true` or `--<flag>=false`.
-For example:
-.PP
-.EX
-yaylog --explicit=true --dependencies=false
-.EE
-.TP
-- When using multiple short flags, the `-n` flag must be last since it consumes the next argument.
-This follows standard Unix-style flag parsing, where positional arguments (like numbers) are treated as separate parameters.
-Invalid:
-.PP
-.EX
-yaylog -ne 15  # incorrect usage
-.EE
-Valid:
-.PP
-.EX
-yaylog -en 15
-.EE
-.TP
-- The `depends`, `required-by`, and `provides` columns output can be lengthy. To improve readability, pipe the output to `less`:
-.PP
-.EX
-yaylog --columns name,depends | less
-.EE
 
 .SH EXAMPLES
 .TP
@@ -263,6 +230,29 @@ Output JSON with specific columns:
 .PP
 .EX
 yaylog --json --columns name,version,size
+.EE
+
+.SH ADDITIONAL NOTES
+.TP
+- All options that take an argument can also be used in the `--<flag>=<argument>` format.
+For example:
+.PP
+.EX
+yaylog --size=100MB:1GB --date=:2024-06-30
+yaylog --name="gtk" --sort=alphabetical
+.EE
+.TP
+- Boolean flags can be explicitly set using `--<flag>=true` or `--<flag>=false`.
+For example:
+.PP
+.EX
+yaylog --explicit=true --dependencies=false
+.EE
+.TP
+- The `depends`, `required-by`, and `provides` columns output can be lengthy. To improve readability, pipe the output to `less`:
+.PP
+.EX
+yaylog --columns name,depends | less
 .EE
 
 .SH AUTHOR


### PR DESCRIPTION
Users can now output all available columns with `--all-columns`. 

Note that the output will be very, very, long. Pipe it with `less` or `moar`.