### PR TITLE
Feature: `--no-headers` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ yaylog [options]
   - `date` (default) - sort by installation date
   - `alphabetical` - sort alphabetically by package name
   - `size:asc` / `size:desc` - sort by package size (ascending or descending)
+- `--no-headers`: omit column headers in table output (useful for scripting)
 - `--columns <list>`: comma-separated list of columns to display (overrides defaults)
 - `--add-columns <list>`: comma-separated list of columns to add to defaults
 - `--all-columns`: show all available columns in the output (overrides defaults)
@@ -218,6 +219,10 @@ are treated as separate parameters.
 
   **note**: `--no-progress` is automatically set to `true` when in a non-interactive environment, so you can pipe `|` into programs like `cat`, `grep`, or `less` without issue
 
+- the `--no-headers` flag is useful when processing output in scripts. It removes the header row, making it easier to parse package lists with tools like `awk`, `sed`, or `cut`:
+  ```bash
+  yaylog --no-headers --columns name,size | awk '{print $1, $2}'
+  ```
 
 ### examples
 
@@ -308,4 +313,8 @@ are treated as separate parameters.
 22. output all packages with all columns/fields in JSON format:
    ```bash
    yaylog -a --all-columns --json
+   ```
+23. show package names and sizes without headers for scripting:
+   ```bash
+   yaylog --no-headers --columns name,size
    ```

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ because yay is my preferred AUR helper and the name has a good flow.
 - [ ] name exclusion filter
 - [ ] self-referencing column
 - [x] JSON output
-- [ ] no-headers option
+- [x] no-headers option
 - [ ] provides filter
 - [ ] depends filter
 - [ ] all-columns option

--- a/cmd/yaylog/main.go
+++ b/cmd/yaylog/main.go
@@ -47,7 +47,7 @@ func main() {
 	if cfg.OutputJson {
 		out.PrintJson(packages, cfg.ColumnNames)
 	} else {
-		out.PrintTable(packages, cfg.ShowFullTimestamp, cfg.ColumnNames)
+		out.PrintTable(packages, cfg.ColumnNames, cfg.ShowFullTimestamp, cfg.HasNoHeaders)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,7 +34,6 @@ type Config struct {
 	DisableProgress   bool
 	ExplicitOnly      bool
 	DependenciesOnly  bool
-	NoDefaults        bool
 	DateFilter        DateFilter
 	SizeFilter        SizeFilter
 	NameFilter        string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	AllPackages       bool
 	ShowHelp          bool
 	OutputJson        bool
+	HasNoHeaders      bool
 	ShowFullTimestamp bool
 	DisableProgress   bool
 	ExplicitOnly      bool
@@ -43,13 +44,16 @@ type Config struct {
 
 func ParseFlags(args []string) (Config, error) {
 	var count int
+
 	var allPackages bool
 	var showHelp bool
 	var outputJson bool
+	var hasNoHeaders bool
 	var showFullTimestamp bool
 	var disableProgress bool
 	var explicitOnly bool
 	var dependenciesOnly bool
+
 	var dateFilter string
 	var sizeFilter string
 	var nameFilter string
@@ -62,6 +66,7 @@ func ParseFlags(args []string) (Config, error) {
 	pflag.BoolVarP(&allPackages, "all", "a", false, "Show all packages (ignores -n)")
 	pflag.BoolVarP(&showHelp, "help", "h", false, "Display help")
 	pflag.BoolVarP(&outputJson, "json", "", false, "Output results in JSON format")
+	pflag.BoolVarP(&hasNoHeaders, "no-headers", "", false, "Hide headers for columns (useful for scripts/automation)")
 	pflag.BoolVarP(&showFullTimestamp, "full-timestamp", "", false, "Show full timestamp instead of just the date")
 	pflag.BoolVarP(&disableProgress, "no-progress", "", false, "Force suppress progress output")
 	pflag.BoolVarP(&explicitOnly, "explicit", "e", false, "Show only explicitly installed packages")
@@ -102,6 +107,7 @@ func ParseFlags(args []string) (Config, error) {
 		AllPackages:       allPackages,
 		ShowHelp:          showHelp,
 		OutputJson:        outputJson,
+		HasNoHeaders:      hasNoHeaders,
 		ShowFullTimestamp: showFullTimestamp,
 		DisableProgress:   disableProgress,
 		ExplicitOnly:      explicitOnly,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -333,6 +333,7 @@ func PrintHelp() {
 	fmt.Println("\nColumn Options:")
 	fmt.Println("  --columns <list>     Comma-separated list of columns to display (overrides defaults)")
 	fmt.Println("  --add-columns <list> Comma-separated list of columns to add to defaults")
+	fmt.Println("  --no-headers         Omit column headers in output (useful for scripts and automation)")
 
 	fmt.Println("\nAvailable Columns:")
 	fmt.Println("  date         - Installation date of the package")

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -54,14 +54,14 @@ func ClearProgress() {
 	manager.clearProgress()
 }
 
-func PrintTable(pkgs []pkgdata.PackageInfo, showFullTimestamp bool, columnNames []string) {
+func PrintTable(pkgs []pkgdata.PackageInfo, columnNames []string, showFullTimestamp bool, hasNoHeaders bool) {
 	dateFormat := consts.DateOnlyFormat
 
 	if showFullTimestamp {
 		dateFormat = consts.DateTimeFormat
 	}
 
-	manager.printTable(pkgs, dateFormat, columnNames)
+	manager.printTable(pkgs, dateFormat, columnNames, hasNoHeaders)
 }
 
 func PrintJson(pkgs []pkgdata.PackageInfo, columnNames []string) {
@@ -118,6 +118,7 @@ func (o *OutputManager) printTable(
 	packages []pkgdata.PackageInfo,
 	dateFormat string,
 	columnNames []string,
+	hasNoHeaders bool,
 ) {
 	o.clearProgress()
 	ctx := displayContext{DateFormat: dateFormat}
@@ -125,7 +126,9 @@ func (o *OutputManager) printTable(
 	var buffer bytes.Buffer
 	w := tabwriter.NewWriter(&buffer, 0, 8, 2, ' ', 0)
 
-	renderHeaders(w, columnNames)
+	if !hasNoHeaders {
+		renderHeaders(w, columnNames)
+	}
 
 	for _, pkg := range packages {
 		renderRows(w, pkg, columnNames, ctx)

--- a/yaylog.1
+++ b/yaylog.1
@@ -95,6 +95,9 @@ Sort results by the specified mode. Available modes:
 .B size:desc
 : Sort by package size in descending order.
 .TP
+.TP
+.B \-\-no-headers
+Omit column headers in table output. This is useful for scripting, as it produces cleaner output without requiring manual header removal.
 .B \-\-columns <list>
 Specify a comma-separated list of columns to display. Overrides default columns.
 Available columns:
@@ -231,6 +234,24 @@ Output JSON with specific columns:
 .EX
 yaylog --json --columns name,version,size
 .EE
+.TP
+Show package names and sizes without headers (useful for scripting):
+.PP
+.EX
+yaylog --no-headers --columns name,size
+.EE
+.TP
+Output all package names, sorted by size in descending order, without headers:
+.PP
+.EX
+yaylog --no-headers --sort size:desc | awk '{print $1}'
+.EE
+.TP
+Save a clean list of installed package names to a file:
+.PP
+.EX
+yaylog --no-headers --columns name > installed-packages.txt
+.EE
 
 .SH ADDITIONAL NOTES
 .TP
@@ -253,6 +274,12 @@ yaylog --explicit=true --dependencies=false
 .PP
 .EX
 yaylog --columns name,depends | less
+.EE
+.TP
+- The `--no-headers` flag is particularly useful when processing package lists in scripts. It removes the header row, making it easier to parse package names and sizes using tools like `awk`, `sed`, or `cut`:
+.PP
+.EX
+yaylog --no-headers --columns name,size | awk '{print $1, $2}'
 .EE
 
 .SH AUTHOR


### PR DESCRIPTION
Users now have the `--no-headers` option to omit column headers in table output.

This can be particularly useful when processing package lists in scripts. It removes the header row, making it easier to parse package names and sizes using tools like `awk`, `sed`, or `cut`:
```bash
yaylog --no-headers --columns name,size | awk '{print $1, $2}'
```

Addresses #63 