### PR TITLE
Feature: `--required by` filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ because yay is my preferred AUR helper and the name has a good flow.
 - [ ] depends filter
 - [x] all-columns option
 - [x] required-by filter
+- [ ] key/value output
+- [ ] list of packages in required-by filter
 
 ## installation
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ this package is compatible with the following distributions:
 - display package versions 
 - filter results by explicitly installed packages
 - filter results by packages installed as dependencies
+- filter by packages required by a specific package
 - sort results by installation date, alphabetically, or by size on disk
 - filter results by a specific installation date or date range
 - filter results by package size or size range
@@ -73,7 +74,7 @@ because yay is my preferred AUR helper and the name has a good flow.
 - [ ] provides filter
 - [ ] depends filter
 - [x] all-columns option
-- [ ] required-by filter
+- [x] required-by filter
 
 ## installation
 
@@ -146,6 +147,7 @@ yaylog [options]
 - `--full-timestamp`: display the full timestamp (date and time) of package installations instead of just the date
 - `--json`: output results in JSON format (overrides table output and `--full-timestamp`)
 - `--no-progress`: force no progress bar outside of non-interactive environments
+- `--required-by <package-name>`: show only packages that are required by the specified package
 - `-h` | `--help`: print help info
 
 ### available columns
@@ -317,4 +319,16 @@ are treated as separate parameters.
 23. show package names and sizes without headers for scripting:
    ```bash
    yaylog --no-headers --columns name,size
+   ```
+24. show all packages required by "firefox":
+   ```bash
+   yaylog --required-by firefox
+   ```
+25. show all packages required by "gtk3" that are at least 50MB in size:
+   ```bash
+   yaylog --required-by gtk3 --size 50MB:
+   ```
+26. show packages required by "vlc" and installed after January 1, 2024:
+   ```bash
+   yaylog --required-by vlc --date 2024-01-01:
    ```

--- a/cmd/yaylog/main.go
+++ b/cmd/yaylog/main.go
@@ -90,6 +90,15 @@ func applyFilters(
 ) []pkgdata.PackageInfo {
 	filters := make([]pkgdata.FilterCondition, 0)
 
+	if len(cfg.RequiredByFilter) > 0 {
+		filters = append(filters, pkgdata.FilterCondition{
+			Filter: func(pkg pkgdata.PackageInfo) bool {
+				return pkgdata.FilterRequiredBy(pkg, cfg.RequiredByFilter)
+			},
+			PhaseName: "Filter by required package",
+		})
+	}
+
 	if cfg.ExplicitOnly {
 		filters = append(filters, pkgdata.FilterCondition{
 			Filter:    pkgdata.FilterExplicit,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	DateFilter        DateFilter
 	SizeFilter        SizeFilter
 	NameFilter        string
+	RequiredByFilter  string
 	SortBy            string
 	ColumnNames       []string
 }
@@ -53,6 +54,7 @@ func ParseFlags(args []string) (Config, error) {
 	var dateFilter string
 	var sizeFilter string
 	var nameFilter string
+	var requiredByFilter string
 	var sortBy string
 	var columnsInput string
 	var addColumnsInput string
@@ -70,6 +72,8 @@ func ParseFlags(args []string) (Config, error) {
 	pflag.StringVar(&dateFilter, "date", "", "Filter packages by installation date. Supports exact dates (YYYY-MM-DD), ranges (YYYY-MM-DD:YYYY-MM-DD), and open-ended filters (:YYYY-MM-DD or YYYY-MM-DD:).")
 	pflag.StringVar(&sizeFilter, "size", "", "Filter packages by size. Supports ranges (e.g., 10MB:20GB), exact matches (e.g., 5MB), and open-ended values (e.g., :2GB or 500KB:)")
 	pflag.StringVar(&nameFilter, "name", "", "Filter packages by name (or similar name)")
+	pflag.StringVar(&requiredByFilter, "required-by", "", "Filter packages by names of packages that require them")
+
 	pflag.StringVar(&sortBy, "sort", "date", "Sort packages by: 'date', 'alphabetical', 'size:desc', 'size:asc'")
 	pflag.StringVar(&columnsInput, "columns", "", "Comma-separated list of columns to display (overrides defaults)")
 	pflag.StringVar(&addColumnsInput, "add-columns", "", "Comma-separated list of columns to add to defaults")
@@ -109,6 +113,7 @@ func ParseFlags(args []string) (Config, error) {
 		DateFilter:        dateFilterParsed,
 		SizeFilter:        sizeFilterParsed,
 		NameFilter:        nameFilter,
+		RequiredByFilter:  requiredByFilter,
 		SortBy:            sortBy,
 		ColumnNames:       columnsParsed,
 	}, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,26 +63,32 @@ func ParseFlags(args []string) (Config, error) {
 	var columnsInput string
 	var addColumnsInput string
 
-	pflag.IntVarP(&count, "number", "n", 20, "Number of packages to show")
+	pflag.CommandLine.SortFlags = false
 
+	pflag.IntVarP(&count, "number", "n", 20, "Number of packages to show")
 	pflag.BoolVarP(&allPackages, "all", "a", false, "Show all packages (ignores -n)")
-	pflag.BoolVarP(&hasAllColumns, "all-columns", "", false, "Show all available columns/fields in the output (overrides defaults)")
-	pflag.BoolVarP(&showHelp, "help", "h", false, "Display help")
-	pflag.BoolVarP(&outputJson, "json", "", false, "Output results in JSON format")
-	pflag.BoolVarP(&hasNoHeaders, "no-headers", "", false, "Hide headers for columns (useful for scripts/automation)")
-	pflag.BoolVarP(&showFullTimestamp, "full-timestamp", "", false, "Show full timestamp instead of just the date")
-	pflag.BoolVarP(&disableProgress, "no-progress", "", false, "Force suppress progress output")
+
 	pflag.BoolVarP(&explicitOnly, "explicit", "e", false, "Show only explicitly installed packages")
 	pflag.BoolVarP(&dependenciesOnly, "dependencies", "d", false, "Show only packages installed as dependencies")
 
 	pflag.StringVar(&dateFilter, "date", "", "Filter packages by installation date. Supports exact dates (YYYY-MM-DD), ranges (YYYY-MM-DD:YYYY-MM-DD), and open-ended filters (:YYYY-MM-DD or YYYY-MM-DD:).")
 	pflag.StringVar(&sizeFilter, "size", "", "Filter packages by size. Supports ranges (e.g., 10MB:20GB), exact matches (e.g., 5MB), and open-ended values (e.g., :2GB or 500KB:)")
 	pflag.StringVar(&nameFilter, "name", "", "Filter packages by name (or similar name)")
-	pflag.StringVar(&requiredByFilter, "required-by", "", "Filter packages by names of packages that require them")
 
 	pflag.StringVar(&sortBy, "sort", "date", "Sort packages by: 'date', 'alphabetical', 'size:desc', 'size:asc'")
+
+	pflag.BoolVarP(&hasNoHeaders, "no-headers", "", false, "Hide headers for columns (useful for scripts/automation)")
+
+	pflag.BoolVarP(&hasAllColumns, "all-columns", "", false, "Show all available columns/fields in the output (overrides defaults)")
 	pflag.StringVar(&columnsInput, "columns", "", "Comma-separated list of columns to display (overrides defaults)")
 	pflag.StringVar(&addColumnsInput, "add-columns", "", "Comma-separated list of columns to add to defaults")
+
+	pflag.BoolVarP(&showFullTimestamp, "full-timestamp", "", false, "Show full timestamp instead of just the date")
+	pflag.BoolVarP(&outputJson, "json", "", false, "Output results in JSON format")
+	pflag.BoolVarP(&disableProgress, "no-progress", "", false, "Force suppress progress output")
+	pflag.StringVar(&requiredByFilter, "required-by", "", "Show only packages that are required by the specified package")
+
+	pflag.BoolVarP(&showHelp, "help", "h", false, "Display help")
 
 	if err := pflag.CommandLine.Parse(args); err != nil {
 		return Config{}, fmt.Errorf("Error parsing flags: %v", err)
@@ -335,9 +341,13 @@ func PrintHelp() {
 	fmt.Println("  --name <search-term> Filter packages by name (substring match)")
 	fmt.Println("                         Example: 'gtk' matches 'gtk3', 'libgtk', etc")
 
+	fmt.Println("  --required-by <name> Show only packages that are required by the specified package")
+	fmt.Println("                         Example: 'yaylog --required-by firefox' lists packages that firefox depends on")
+
 	fmt.Println("\nColumn Options:")
 	fmt.Println("  --columns <list>     Comma-separated list of columns to display (overrides defaults)")
 	fmt.Println("  --add-columns <list> Comma-separated list of columns to add to defaults")
+	fmt.Println("  --all-columns        Display all available columns")
 	fmt.Println("  --no-headers         Omit column headers in output (useful for scripts and automation)")
 
 	fmt.Println("\nAvailable Columns:")

--- a/internal/pkgdata/filters.go
+++ b/internal/pkgdata/filters.go
@@ -17,10 +17,8 @@ type FilterCondition struct {
 func FilterRequiredBy(pkg PackageInfo, target string) bool {
 	for _, requiredByPkgName := range pkg.RequiredBy {
 		matches := packageNameRegex.FindStringSubmatch(requiredByPkgName)
-		if len(matches) >= 2 {
-			if matches[1] == target { // TODO: condense
-				return true
-			}
+		if len(matches) >= 2 && matches[1] == target {
+			return true
 		}
 	}
 

--- a/internal/pkgdata/filters.go
+++ b/internal/pkgdata/filters.go
@@ -3,7 +3,6 @@ package pkgdata
 import (
 	"fmt"
 	"math"
-	"regexp"
 	"strings"
 	"time"
 )
@@ -15,12 +14,9 @@ type FilterCondition struct {
 	PhaseName string
 }
 
-// I feel like this shouldn't be here, let's find a better spot for it
-var re = regexp.MustCompile(`^([^<>=]+)`) // pulls package name out of `package-name>=2.0.1`
-
 func FilterRequiredBy(pkg PackageInfo, target string) bool {
 	for _, requiredByPkgName := range pkg.RequiredBy {
-		matches := re.FindStringSubmatch(requiredByPkgName)
+		matches := packageNameRegex.FindStringSubmatch(requiredByPkgName)
 		if len(matches) >= 2 {
 			if matches[1] == target { // TODO: condense
 				return true

--- a/internal/pkgdata/filters.go
+++ b/internal/pkgdata/filters.go
@@ -3,6 +3,7 @@ package pkgdata
 import (
 	"fmt"
 	"math"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -12,6 +13,22 @@ type Filter func(PackageInfo) bool
 type FilterCondition struct {
 	Filter    Filter
 	PhaseName string
+}
+
+// I feel like this shouldn't be here, let's find a better spot for it
+var re = regexp.MustCompile(`^([^<>=]+)`) // pulls package name out of `package-name>=2.0.1`
+
+func FilterRequiredBy(pkg PackageInfo, target string) bool {
+	for _, requiredByPkgName := range pkg.RequiredBy {
+		matches := re.FindStringSubmatch(requiredByPkgName)
+		if len(matches) >= 2 {
+			if matches[1] == target { // TODO: condense
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func FilterExplicit(pkg PackageInfo) bool {

--- a/internal/pkgdata/reverse_dependencies.go
+++ b/internal/pkgdata/reverse_dependencies.go
@@ -9,6 +9,7 @@ import (
 
 var packageNameRegex = regexp.MustCompile(`^([^<>=]+)`) // pulls package name out of `package-name>=2.0.1`
 
+// TODO: we can do this concurrent. let's get on that.
 func CalculateReverseDependencies(
 	cfg config.Config,
 	packages []PackageInfo,

--- a/internal/pkgdata/reverse_dependencies.go
+++ b/internal/pkgdata/reverse_dependencies.go
@@ -12,7 +12,9 @@ func CalculateReverseDependencies(
 	packages []PackageInfo,
 	_ ProgressReporter, // TODO: Add progress reporting
 ) []PackageInfo {
-	if !slices.Contains(cfg.ColumnNames, consts.RequiredBy) {
+	hasRequiredByFilter := len(cfg.RequiredByFilter) > 0
+
+	if !slices.Contains(cfg.ColumnNames, consts.RequiredBy) && !hasRequiredByFilter {
 		return packages
 	}
 

--- a/internal/pkgdata/reverse_dependencies.go
+++ b/internal/pkgdata/reverse_dependencies.go
@@ -7,6 +7,8 @@ import (
 	"yaylog/internal/consts"
 )
 
+var packageNameRegex = regexp.MustCompile(`^([^<>=]+)`) // pulls package name out of `package-name>=2.0.1`
+
 func CalculateReverseDependencies(
 	cfg config.Config,
 	packages []PackageInfo,
@@ -21,7 +23,6 @@ func CalculateReverseDependencies(
 	packagePointerMap := make(map[string]*PackageInfo)
 	packageDependencyMap := make(map[string][]string)
 	providesMap := make(map[string]string) // key: provided library/package, value: package that providers it (provider)
-	re := regexp.MustCompile(`^([^<>=]+)`) // pulls package name out of `package-name>=2.0.1`
 
 	for i := range packages {
 		pkg := &packages[i]
@@ -29,7 +30,7 @@ func CalculateReverseDependencies(
 
 		// populate providesMap
 		for _, provided := range pkg.Provides {
-			matches := re.FindStringSubmatch(provided)
+			matches := packageNameRegex.FindStringSubmatch(provided)
 			if len(matches) >= 2 {
 				providesMap[matches[1]] = pkg.Name
 			}
@@ -38,7 +39,7 @@ func CalculateReverseDependencies(
 
 	for _, pkg := range packages {
 		for _, depPackage := range pkg.Depends {
-			matches := re.FindStringSubmatch(depPackage)
+			matches := packageNameRegex.FindStringSubmatch(depPackage)
 
 			if len(matches) >= 2 {
 				depName := matches[1]

--- a/yaylog.1
+++ b/yaylog.1
@@ -320,12 +320,13 @@ This project is licensed under the MIT License. See the
 file for details.
 
 .SH BUGS
-Report bugs to the GitHub repository:
+Report bugs at:
 .UR https://github.com/Zweih/yaylog
-.LI https://github.com/Zweih/yaylog
+https://github.com/Zweih/yaylog
 .UE
 
+
 .SH SEE ALSO
-.B pacman(8),
-.B yay(8)
+.BR pacman(8),
+.BR yay(8)
 

--- a/yaylog.1
+++ b/yaylog.1
@@ -1,10 +1,10 @@
 .\" Man page for yaylog
-.TH yaylog 1 "March 2025" "yaylog 3.14.0" "User Commands"
+.TH yaylog 1 "March 2025" "yaylog 3.17.0" "User Commands"
 .SH NAME
 yaylog \- List and filter installed packages on Arch-based systems.
 .SH SYNOPSIS
 .B yaylog
-.RI [ \-n | \-\-number <number> ] [ \-e | \-\-explicit ] [ \-a | \-\-all ] [ \-d | \-\-dependencies ] [ \-\-date <filter> ] [ \-\-size <filter> ] [ \-\-name <search-term> ] [ \-\-sort <mode> ] [ \-\-columns <list> ] [ \-\-add-columns <list> ] [ \-\-all-columns ] [ \-\-json ] [ \-\-full-timestamp ] [ \-\-no-progress ] [ \-h | \-\-help ]
+.RI [ \-n | \-\-number <number> ] [ \-e | \-\-explicit ] [ \-a | \-\-all ] [ \-d | \-\-dependencies ] [ \-\-required-by <package> ] [ \-\-date <filter> ] [ \-\-size <filter> ] [ \-\-name <search-term> ] [ \-\-sort <mode> ] [ \-\-columns <list> ] [ \-\-add-columns <list> ] [ \-\-all-columns ] [ \-\-json ] [ \-\-full-timestamp ] [ \-\-no-progress ] [ \-h | \-\-help ]
 .SH DESCRIPTION
 .B yaylog
 is a standalone CLI utility for Arch and Arch-based Linux distributions to list and filter installed packages. It works with any package manager that uses ALPM,
@@ -15,7 +15,7 @@ including
 .B pacman,
 and others.
 
-The utility provides options to filter by explicitly installed packages, dependencies, installation dates, package sizes, and package names. It also supports sorting results by date, alphabetical order, or size.
+The utility provides options to filter by explicitly installed packages, dependencies, installation dates, package sizes, package names, and by packages required by another package. It also supports sorting results by date, alphabetical order, or size.
 
 .SH OPTIONS
 .TP
@@ -38,6 +38,18 @@ Show all installed packages, ignoring the
 or
 .B \-\-number
 option.
+.TP
+.B \-\-required-by <package>
+Show only packages that are required by the specified package.
+For example, running:
+.PP
+.EX
+yaylog --required-by firefox
+.EE
+.PP
+will display all packages that
+.B firefox
+depends on.
 .TP
 .B \-\-date <filter>
 Filter packages by installation date. Supports exact dates and ranges:
@@ -95,9 +107,9 @@ Sort results by the specified mode. Available modes:
 .B size:desc
 : Sort by package size in descending order.
 .TP
-.TP
 .B \-\-no-headers
 Omit column headers in table output. This is useful for scripting, as it produces cleaner output without requiring manual header removal.
+.TP
 .B \-\-columns <list>
 Specify a comma-separated list of columns to display. Overrides default columns.
 Available columns:
@@ -193,93 +205,28 @@ Show only dependencies installed between July 1, 2023, and December 31, 2023:
 yaylog -d --date 2023-07-01:2023-12-31
 .EE
 .TP
+Show all packages required by "firefox":
+.PP
+.EX
+yaylog --required-by firefox
+.EE
+.TP
+Show all packages required by "gtk3" that are at least 50MB in size:
+.PP
+.EX
+yaylog --required-by gtk3 --size 50MB:
+.EE
+.TP
+Show packages required by "vlc" and installed after January 1, 2024:
+.PP
+.EX
+yaylog --required-by vlc --date 2024-01-01:
+.EE
+.TP
 Show packages between 500KB and 5MB installed up to June 30, 2024:
 .PP
 .EX
 yaylog --size 500KB:5MB --date :2024-06-30
-.EE
-.TP
-Show packages larger than 1GB installed on December 1, 2024:
-.PP
-.EX
-yaylog --size 1GB: --date 2024-12-01
-.EE
-.TP
-Show all packages sorted by size in descending order, installed after January 1, 2024:
-.PP
-.EX
-yaylog -a --sort size:desc --date 2024-01-01:
-.EE
-.TP
-Output package data in JSON format:
-.PP
-.EX
-yaylog --json
-.EE
-.TP
-Save all explicitly installed packages to a JSON file:
-.PP
-.EX
-yaylog --json -e > explicit-packages.json
-.EE
-.TP
-Output all packages sorted by size (descending) in JSON:
-.PP
-.EX
-yaylog --json -a --sort size:desc
-.EE
-.TP
-Output JSON with specific columns:
-.PP
-.EX
-yaylog --json --columns name,version,size
-.EE
-.TP
-Show package names and sizes without headers (useful for scripting):
-.PP
-.EX
-yaylog --no-headers --columns name,size
-.EE
-.TP
-Output all package names, sorted by size in descending order, without headers:
-.PP
-.EX
-yaylog --no-headers --sort size:desc | awk '{print $1}'
-.EE
-.TP
-Save a clean list of installed package names to a file:
-.PP
-.EX
-yaylog --no-headers --columns name > installed-packages.txt
-.EE
-
-.SH ADDITIONAL NOTES
-.TP
-- All options that take an argument can also be used in the `--<flag>=<argument>` format.
-For example:
-.PP
-.EX
-yaylog --size=100MB:1GB --date=:2024-06-30
-yaylog --name="gtk" --sort=alphabetical
-.EE
-.TP
-- Boolean flags can be explicitly set using `--<flag>=true` or `--<flag>=false`.
-For example:
-.PP
-.EX
-yaylog --explicit=true --dependencies=false
-.EE
-.TP
-- The `depends`, `required-by`, and `provides` columns output can be lengthy. To improve readability, pipe the output to `less`:
-.PP
-.EX
-yaylog --columns name,depends | less
-.EE
-.TP
-- The `--no-headers` flag is particularly useful when processing package lists in scripts. It removes the header row, making it easier to parse package names and sizes using tools like `awk`, `sed`, or `cut`:
-.PP
-.EX
-yaylog --no-headers --columns name,size | awk '{print $1, $2}'
 .EE
 
 .SH AUTHOR

--- a/yaylog.1
+++ b/yaylog.1
@@ -205,6 +205,66 @@ Show only dependencies installed between July 1, 2023, and December 31, 2023:
 yaylog -d --date 2023-07-01:2023-12-31
 .EE
 .TP
+Show packages between 500KB and 5MB installed up to June 30, 2024:
+.PP
+.EX
+yaylog --size 500KB:5MB --date :2024-06-30
+.EE
+.TP
+Show packages larger than 1GB installed on December 1, 2024:
+.PP
+.EX
+yaylog --size 1GB: --date 2024-12-01
+.EE
+.TP
+Show all packages sorted by size in descending order, installed after January 1, 2024:
+.PP
+.EX
+yaylog -a --sort size:desc --date 2024-01-01:
+.EE
+.TP
+Output package data in JSON format:
+.PP
+.EX
+yaylog --json
+.EE
+.TP
+Save all explicitly installed packages to a JSON file:
+.PP
+.EX
+yaylog --json -e > explicit-packages.json
+.EE
+.TP
+Output all packages sorted by size (descending) in JSON:
+.PP
+.EX
+yaylog --json -a --sort size:desc
+.EE
+.TP
+Output JSON with specific columns:
+.PP
+.EX
+yaylog --json --columns name,version,size
+.EE
+.TP
+Show package names and sizes without headers (useful for scripting):
+.PP
+.EX
+yaylog --no-headers --columns name,size
+.EE
+.TP
+Output all package names, sorted by size in descending order, without headers:
+.PP
+.EX
+yaylog --no-headers --sort size:desc | awk '{print $1}'
+.EE
+.TP
+Save a clean list of installed package names to a file:
+.PP
+.EX
+yaylog --no-headers --columns name > installed-packages.txt
+.EE
+.TP
 Show all packages required by "firefox":
 .PP
 .EX
@@ -222,11 +282,34 @@ Show packages required by "vlc" and installed after January 1, 2024:
 .EX
 yaylog --required-by vlc --date 2024-01-01:
 .EE
+
+.SH ADDITIONAL NOTES
 .TP
-Show packages between 500KB and 5MB installed up to June 30, 2024:
+- All options that take an argument can also be used in the `--<flag>=<argument>` format.
+For example:
 .PP
 .EX
-yaylog --size 500KB:5MB --date :2024-06-30
+yaylog --size=100MB:1GB --date=:2024-06-30
+yaylog --name="gtk" --sort=alphabetical
+.EE
+.TP
+- Boolean flags can be explicitly set using `--<flag>=true` or `--<flag>=false`.
+For example:
+.PP
+.EX
+yaylog --explicit=true --dependencies=false
+.EE
+.TP
+- The `depends`, `required-by`, and `provides` columns output can be lengthy. To improve readability, pipe the output to `less`:
+.PP
+.EX
+yaylog --columns name,depends | less
+.EE
+.TP
+- The `--no-headers` flag is particularly useful when processing package lists in scripts. It removes the header row, making it easier to parse package names and sizes using tools like `awk`, `sed`, or `cut`:
+.PP
+.EX
+yaylog --no-headers --columns name,size | awk '{print $1, $2}'
 .EE
 
 .SH AUTHOR


### PR DESCRIPTION
Users can now filter by packages required by a specific package.

Show all packages required by "firefox":
   ```bash
   yaylog --required-by firefox
   ```

The help menu has also been rearranged a bit.

Addresses #63 