### PR TITLE
Feature: depends filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ because yay is my preferred AUR helper and the name has a good flow.
 - [x] JSON output
 - [x] no-headers option
 - [ ] provides filter
-- [ ] depends filter
+- [x] depends filter
 - [x] all-columns option
 - [x] required-by filter
 - [ ] key/value output
@@ -128,11 +128,12 @@ yaylog [options]
 - `-n <number>` | `--number <number>`: number of recent packages to display (default: 20)
 - `-a` | `all`: show all installed packages (ignores `-n`)
 - `-f <field>=<value>` | `--filter <field>=<value>`: apply multiple filters for a flexible query system. can be used multiple times. example:
-  - `--filter size=10MB:1GB` -> filter by size range
+  - `--filter size=10MB:1GB`    -> filter by size range
   - `--filter date=2024-01-01:` -> filter by installation date
-  - `--filter name=firefox` -> filter by package name
-  - `--filter reason=explicit` -> filter by explicit installations
-  - `--filter required-by=vlc` -> show packages required by VLC
+  - `--filter name=firefox`     -> filter by package names that contain `firefox`
+  - `--filter reason=explicit`  -> filter by explicit installations
+  - `--filter required-by=vlc`  -> filter by packages required by `vlc`
+  - `--filter depends=glibc`    -> filter by packages that depend on `glibc`
 - `--sort <mode>`: sort results by:
   - `date` (default) - sort by installation date
   - `alphabetical` - sort alphabetically by package name
@@ -156,7 +157,8 @@ short-flag filters and long-flag filters can be combined.
 | filter type  | syntax | description |
 |-------------|--------|-------------|
 | **date** | `date=<value>` | filters by installation date. supports exact dates, ranges (`YYYY-MM-DD:YYYY-MM-DD`), and open-ended ranges (`YYYY-MM-DD:` or `:YYYY-MM-DD`) |
-| **required by** | `required-by=<package>` | shows only packages that are required by a specific package |
+| **required by** | `required-by=<package>` | filters by packages that are required by a specific package |
+| **depends** | `depends=<package>` | filters by packages that have a specific package as a dependency |
 | **nme** | `name=<package>` |  filters by package name (substring match) |
 | **installation reason** | `reason=explicit` / `reason=dependencies` | filters packages by installation reason: explicitly installed or installed as a dependency |
 | **size** | `size=<value>` | filters by package size on disk. supports exact values (`10MB`), ranges (`10MB:1GB`), and open-ended ranges (`:500KB`, `1GB:`) |
@@ -266,7 +268,7 @@ are treated as separate parameters.
    ```
  3. show only dependencies installed on a specific date
    ```bash
-   yaylog -f reason=dependencies -f date=2024-12-25
+   yaylog -f reason=dependencies -f date=2025-03-01
    ```
  4. show all packages sorted alphabetically
    ```bash
@@ -292,9 +294,9 @@ are treated as separate parameters.
    ```bash
    yaylog -f size=100MB:1GB -f date=:2024-06-30
    ```
-10. show all packages sorted by size in descending order, installed after january 1, 2024
+10. show all packages sorted by size in descending order, installed after january 1, 2025
    ```bash
-   yaylog -a --sort size:desc -f date=2024-01-01:
+   yaylog -a --sort size:desc -f date=2025-01-01:
    ```
 11. search for installed packages containing "python
    ```bash
@@ -304,13 +306,13 @@ are treated as separate parameters.
    ```bash
    yaylog -f reason=explicit -f name=lib -f size=10MB:1GB
    ```
-13. search for packages containing "linux" installed between january 1 and june 30, 2024
+13. search for packages with names containing "linux" installed between january 1 and june 30, 2024
    ```bash
    yaylog -f name=linux -f date=2024-01-01:2024-06-30
    ```
-14. search for packages containing "gtk" installed after january 1, 2023, and at least 5MB in size
+14. search for packages containing "gtk" installed after january 1, 2025, and at least 5MB in size
    ```bash
-   yaylog -f name=gtk -f date=2023-01-01: -f size=5MB:
+   yaylog -f name=gtk -f date=2025-01-01: -f size=5MB:
    ```
 15. show packages with name, version, and size
    ```bash
@@ -348,15 +350,19 @@ are treated as separate parameters.
    ```bash
    yaylog --no-headers --columns name,size
    ```
-24. show all packages required by "firefox"
+24. show all packages required by `firefox`
    ```bash
    yaylog -f required-by=firefox
    ```
-25. show all packages required by "gtk3" that are at least 50MB in size
+25. show all packages required by `gtk3` that are at least 50MB in size
    ```bash
    yaylog -f required-by=gtk3 -f size=50MB:
    ```
-26. show packages required by "vlc" and installed after january 1, 2024 
+26. show packages required by `vlc` and installed after january 1, 2024 
    ```bash
    yaylog -f required-by=vlc -f date=2024-01-01:
    ```
+27. show all packages that have `glibc` as a dependency and are required by `ffmpeg`
+   ```bash
+   yaylog -f depends=glibc -f required-by=ffmpeg
+    ```

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ because yay is my preferred AUR helper and the name has a good flow.
 - [x] config dependency injection for testing
 - [ ] more extensive testing
 - [x] metaflag for all filters
+- [ ] XML output
+- [ ] short-args for filters
 
 ## installation
 

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -28,6 +28,7 @@ func PrintHelp() {
 	fmt.Println("    reason=explicit           Show only explicitly installed packages")
 	fmt.Println("    reason=dependencies       Show only packages installed as dependencies")
 	fmt.Println("    required-by=vlc           Show packages required by the specified package")
+	fmt.Println("    depends=glibc             Show packages that depend upon a specific package")
 
 	fmt.Println("\nSorting Options:")
 	fmt.Println("  --sort date                 Sort packages by installation date (default)")

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -41,7 +41,7 @@ func queriesToConditions(filterQueries map[consts.FieldType]string) ([]pkgdata.F
 			condition, err = parseDateFilterCondition(value)
 		case consts.FieldSize:
 			condition, err = parseSizeFilterCondition(value)
-		case consts.FieldName, consts.FieldRequiredBy:
+		case consts.FieldName, consts.FieldRequiredBy, consts.FieldDepends:
 			condition, err = NewPackageCondition(fieldType, []string{value})
 		case consts.FieldReason:
 			condition, err = parseReasonFilterCondition(value)

--- a/yaylog.1
+++ b/yaylog.1
@@ -1,5 +1,5 @@
 .\" Man page for yaylog
-.TH yaylog 1 "March 2025" "yaylog 3.18.0" "User Commands"
+.TH yaylog 1 "March 2025" "yaylog 3.19.0" "User Commands"
 .SH NAME
 yaylog \- List and filter installed packages on Arch-based systems.
 .SH SYNOPSIS
@@ -75,6 +75,9 @@ Supported fields:
 .IP
 .B required-by=vlc
 : Show packages required by "vlc".
+.IP
+.B depends=glibc
+: Show packages that depend on glibc
 
 .PP
 For example, to filter all explicitly installed packages larger than 100MB:
@@ -245,6 +248,12 @@ Show package names and sizes without headers (useful for scripting):
 .PP
 .EX
 yaylog --no-headers --columns name,size
+.EE
+.TP
+Show all packages that have "glibc" as a dependency and are required by "ffmpeg":
+.PP
+.EX
+yaylog -f depends=glibc -f required-by=ffmpeg
 .EE
 
 .SH AUTHOR


### PR DESCRIPTION
The previous refactors have paid off, this was only a one line change (excluding documentation). 

Users can now filter packages by their dependencies with `yaylog -f depends=<package-name>`

Addresses #88 