### PR TITLE
Feature: Add conflicts field

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ this package is compatible with the following distributions:
 
 ## features
 
-- list installed packages with date/timestamps, dependencies, provisions, requirements, size on disk, and version
+- list installed packages with date/timestamps, dependencies, provisions, requirements, size on disk, conflicts, and version
 - filter by explicitly installed packages
 - filter by packages installed as dependencies
-- filter by packages required by a specific package
+- filter by packages required by specified packages
+- filter by packages that depend upon specified packages 
 - filter by a specific installation date or date range
 - filter by package size or size range
 - filter by package name (substring match)
@@ -177,6 +178,7 @@ short-flag filters and long-flag filters can be combined.
 - `depends` - list of dependencies (output can be long)
 - `required-by` - list of packages required by the package and are dependent (output can be long) 
 - `provides` - list of alternative package names or shared libraries provided by package (output can be long)
+- `conficts` - list of packages that conflict, or cause problems, with the package
 
 ### JSON output
 the `--json` flag outputs the package data as structured JSON instead of a table. this can be useful for scripts or automation.
@@ -383,4 +385,3 @@ are treated as separate parameters.
    ```bash
    yaylog -f provides=rustc,python3
    ```
-

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -53,7 +53,8 @@ func PrintHelp() {
 	fmt.Println("  version      Installed package version")
 	fmt.Println("  depends      List of dependencies (output can be long)")
 	fmt.Println("  required-by  List of packages that depend on this package (output can be long)")
-	fmt.Println("  provides     List of alternative package names or shared libraries provided")
+	fmt.Println("  provides     List of alternative package names or shared libraries provided (output can be long)")
+	fmt.Println("  conflicts    List of packages that conflict, or cause problems, with the package")
 
 	fmt.Println("\nDeprecated Legacy Options (Use --filter Instead):")
 	fmt.Println("  -e, --explicit              (Deprecated) Show only explicitly installed packages")

--- a/internal/consts/columns.go
+++ b/internal/consts/columns.go
@@ -11,6 +11,7 @@ const (
 	depends    = "depends"
 	requiredBy = "required-by"
 	provides   = "provides"
+	conflicts  = "conflicts"
 )
 
 const (
@@ -22,6 +23,7 @@ const (
 	FieldDepends    FieldType = depends
 	FieldRequiredBy FieldType = requiredBy
 	FieldProvides   FieldType = provides
+	FieldConflicts  FieldType = conflicts
 )
 
 var FieldTypeLookup = map[string]FieldType{
@@ -42,6 +44,7 @@ var FieldTypeLookup = map[string]FieldType{
 	depends:    FieldDepends,
 	requiredBy: FieldRequiredBy,
 	provides:   FieldProvides,
+	conflicts:  FieldConflicts,
 }
 
 var (
@@ -60,5 +63,6 @@ var (
 		FieldDepends,
 		FieldRequiredBy,
 		FieldProvides,
+		FieldConflicts,
 	}
 )

--- a/internal/display/render_table.go
+++ b/internal/display/render_table.go
@@ -22,6 +22,7 @@ var columnHeaders = map[consts.FieldType]string{
 	consts.FieldDepends:    "DEPENDS",
 	consts.FieldRequiredBy: "REQUIRED BY",
 	consts.FieldProvides:   "PROVIDES",
+	consts.FieldConflicts:  "CONFLICTS",
 }
 
 // displays data in tab format
@@ -96,6 +97,8 @@ func getTableValue(pkg pkgdata.PackageInfo, field consts.FieldType, ctx tableCon
 		return formatPackageList(pkg.RequiredBy)
 	case consts.FieldProvides:
 		return formatPackageList(pkg.Provides)
+	case consts.FieldConflicts:
+		return formatPackageList(pkg.Conflicts)
 	default:
 		return ""
 	}

--- a/internal/pkgdata/fetch.go
+++ b/internal/pkgdata/fetch.go
@@ -21,6 +21,7 @@ const (
 	fieldVersion     = "%VERSION%"
 	fieldDepends     = "%DEPENDS%"
 	fieldProvides    = "%PROVIDES%"
+	fieldConflicts   = "%CONFLICTS%"
 	pacmanDbPath     = "/var/lib/pacman/local"
 )
 
@@ -40,7 +41,7 @@ func FetchPackages() ([]PackageInfo, error) {
 	// fun fact: NumCPU() does account for hyperthreading
 	numWorkers := getWorkerCount(runtime.NumCPU(), numPackages)
 
-	for i := 0; i < numWorkers; i++ {
+	for range numWorkers {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -121,7 +122,7 @@ func parseDescFile(descPath string) (PackageInfo, error) {
 		line := strings.TrimSpace(scanner.Text())
 
 		switch line {
-		case fieldName, fieldInstallDate, fieldSize, fieldReason, fieldVersion, fieldDepends, fieldProvides:
+		case fieldName, fieldInstallDate, fieldSize, fieldReason, fieldVersion, fieldDepends, fieldProvides, fieldConflicts:
 			currentField = line
 		case "":
 			currentField = "" // reset if line is blank
@@ -180,6 +181,9 @@ func applyField(pkg *PackageInfo, field string, value string) error {
 
 	case fieldProvides:
 		pkg.Provides = append(pkg.Provides, value)
+
+	case fieldConflicts:
+		pkg.Conflicts = append(pkg.Provides, value)
 
 	default:
 		// ignore unknown fields

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -10,6 +10,7 @@ type BasePackageInfo struct {
 	Depends    []string `json:"depends,omitempty"`
 	RequiredBy []string `json:"requiredBy,omitempty"`
 	Provides   []string `json:"provides,omitempty"`
+	Conflicts  []string `json:"conflicts,omitempty"`
 }
 
 // info about a single installed package

--- a/yaylog.1
+++ b/yaylog.1
@@ -133,6 +133,9 @@ Specify a comma-separated list of columns to display. Available columns:
 .IP
 .B provides
 : Alternative package names or shared libraries provided.
+.IP
+.B conflicts
+: List of packages that conflict, or cause problems, with the package
 .TP
 .B \-\-all-columns
 Show all available columns.


### PR DESCRIPTION
Users can now see what packages conflict with each package using `yaylog --add-columns conflicts` or `yaylog --all-columns`.

Addresses #97 