### PR TITLE
Fix: Conflicts field in JSON

### DIFF
--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -42,6 +42,8 @@ func getJsonValues(pkg pkgdata.PackageInfo, fields []consts.FieldType) pkgdata.P
 			filteredPackage.RequiredBy = pkg.RequiredBy
 		case consts.FieldProvides:
 			filteredPackage.Provides = pkg.Provides
+		case consts.FieldConflicts:
+			filteredPackage.Conflicts = pkg.Conflicts
 		}
 	}
 


### PR DESCRIPTION
The conflicts field was not showing up in JSON. This adds it in.

Addresses #102 