### PR TITLE
Feature: Add architecture field

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ because yay is my preferred AUR helper and the name has a good flow.
 - [x] reverse-dependencies of each package (required-by field)
 - [ ] package descriptions
 - [ ] package URLs
-- [ ] package architecture
+- [x] package architecture
 - [x] package conflicts
 - [x] conflicts filter
 - [ ] name exclusion filter
@@ -184,6 +184,7 @@ short-flag filters and long-flag filters can be combined.
 - `required-by` - list of packages required by the package and are dependent (output can be long) 
 - `provides` - list of alternative package names or shared libraries provided by package (output can be long)
 - `conficts` - list of packages that conflict, or cause problems, with the package
+- `arch` - architecture the package was built for (e.g., x86_64, aarch64, any)
 
 ### JSON output
 the `--json` flag outputs the package data as structured JSON instead of a table. this can be useful for scripts or automation.
@@ -221,7 +222,8 @@ output format:
     "provides": [
       "sqlite3=3.48.0",
       "libsqlite3.so=0-64"
-    ]
+    ],
+    "arch": "x86_64"
   }
 ]
 ```

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -56,6 +56,7 @@ func PrintHelp() {
 	fmt.Println("  required-by  List of packages that depend on this package (output can be long)")
 	fmt.Println("  provides     List of alternative package names or shared libraries provided (output can be long)")
 	fmt.Println("  conflicts    List of packages that conflict, or cause problems, with the package")
+	fmt.Println("  arch         Architecture the package was built for")
 
 	fmt.Println("\nDeprecated Legacy Options (Use --filter Instead):")
 	fmt.Println("  -e, --explicit              (Deprecated) Show only explicitly installed packages")

--- a/internal/consts/columns.go
+++ b/internal/consts/columns.go
@@ -12,6 +12,7 @@ const (
 	requiredBy = "required-by"
 	provides   = "provides"
 	conflicts  = "conflicts"
+	arch       = "arch"
 )
 
 const (
@@ -24,6 +25,7 @@ const (
 	FieldRequiredBy FieldType = requiredBy
 	FieldProvides   FieldType = provides
 	FieldConflicts  FieldType = conflicts
+	FieldArch       FieldType = arch
 )
 
 var FieldTypeLookup = map[string]FieldType{
@@ -45,6 +47,7 @@ var FieldTypeLookup = map[string]FieldType{
 	requiredBy: FieldRequiredBy,
 	provides:   FieldProvides,
 	conflicts:  FieldConflicts,
+	arch:       FieldArch,
 }
 
 var (
@@ -64,5 +67,6 @@ var (
 		FieldRequiredBy,
 		FieldProvides,
 		FieldConflicts,
+		FieldArch,
 	}
 )

--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -44,6 +44,8 @@ func getJsonValues(pkg pkgdata.PackageInfo, fields []consts.FieldType) pkgdata.P
 			filteredPackage.Provides = pkg.Provides
 		case consts.FieldConflicts:
 			filteredPackage.Conflicts = pkg.Conflicts
+		case consts.FieldArch:
+			filteredPackage.Arch = pkg.Arch
 		}
 	}
 

--- a/internal/display/render_table.go
+++ b/internal/display/render_table.go
@@ -23,6 +23,7 @@ var columnHeaders = map[consts.FieldType]string{
 	consts.FieldRequiredBy: "REQUIRED BY",
 	consts.FieldProvides:   "PROVIDES",
 	consts.FieldConflicts:  "CONFLICTS",
+	consts.FieldArch:       "ARCH",
 }
 
 // displays data in tab format
@@ -99,6 +100,8 @@ func getTableValue(pkg pkgdata.PackageInfo, field consts.FieldType, ctx tableCon
 		return formatPackageList(pkg.Provides)
 	case consts.FieldConflicts:
 		return formatPackageList(pkg.Conflicts)
+	case consts.FieldArch:
+		return pkg.Arch
 	default:
 		return ""
 	}

--- a/internal/pkgdata/fetch.go
+++ b/internal/pkgdata/fetch.go
@@ -22,7 +22,9 @@ const (
 	fieldDepends     = "%DEPENDS%"
 	fieldProvides    = "%PROVIDES%"
 	fieldConflicts   = "%CONFLICTS%"
-	pacmanDbPath     = "/var/lib/pacman/local"
+	fieldArch        = "%ARCH%"
+
+	pacmanDbPath = "/var/lib/pacman/local"
 )
 
 func FetchPackages() ([]PackageInfo, error) {
@@ -122,7 +124,15 @@ func parseDescFile(descPath string) (PackageInfo, error) {
 		line := strings.TrimSpace(scanner.Text())
 
 		switch line {
-		case fieldName, fieldInstallDate, fieldSize, fieldReason, fieldVersion, fieldDepends, fieldProvides, fieldConflicts:
+		case fieldName,
+			fieldInstallDate,
+			fieldSize,
+			fieldReason,
+			fieldVersion,
+			fieldDepends,
+			fieldProvides,
+			fieldConflicts,
+			fieldArch:
 			currentField = line
 		case "":
 			currentField = "" // reset if line is blank
@@ -184,6 +194,9 @@ func applyField(pkg *PackageInfo, field string, value string) error {
 
 	case fieldConflicts:
 		pkg.Conflicts = append(pkg.Conflicts, value)
+
+	case fieldArch:
+		pkg.Arch = value
 
 	default:
 		// ignore unknown fields

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -11,6 +11,7 @@ type BasePackageInfo struct {
 	RequiredBy []string `json:"requiredBy,omitempty"`
 	Provides   []string `json:"provides,omitempty"`
 	Conflicts  []string `json:"conflicts,omitempty"`
+	Arch       string   `json:"arch,omitempty"`
 }
 
 // info about a single installed package

--- a/yaylog.1
+++ b/yaylog.1
@@ -141,7 +141,10 @@ Specify a comma-separated list of columns to display. Available columns:
 : Alternative package names or shared libraries provided.
 .IP
 .B conflicts
-: List of packages that conflict, or cause problems, with the package
+: List of packages that conflict, or cause problems, with the package.
+.IP
+.B arch
+: Architecture the package was built for. 
 .TP
 .B \-\-all-columns
 Show all available columns.


### PR DESCRIPTION
Users can now list the package architecture with `yaylog --add-columns arch` or `yaylog --columns arch` or `yaylog --all-columns`.

Addresses #99 