### PR TITLE
Refactor: Timestamp

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.1 linguist-language=text

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ short-flag filters and long-flag filters can be combined.
 | **depends** | `depends=<package>` / <br> `depends=<package-1>,<package-2>,<etc>` | filters by packages that have the specified packages as dependencies |
 | **provides** | `provides=<package>` / <br> `provides=<package-1>,<package-2>,<etc>` | filters by package that provide the specified packages/libraries |
 | **conflicts** | `conflicts=<package>` / <br> `conflicts=<package-1,<package-2>,<etc>` | filters by packages that conflict with the specified packages |
-| **architecture** | `arch=<architecture>` / <br> `arch=<architecture-1>,<architecture-2>,<etc>` | filters by packages that are built for the specified architectures. <br> **Note**: "any" is a separate architecture category. If this not is behavior that you prefer/expect, please open an issue. |
+| **architecture** | `arch=<architecture>` / <br> `arch=<architecture-1>,<architecture-2>,<etc>` | filters by packages that are built for the specified architectures <br> **note**: "any" is a separate architecture category |
 | **name** | `name=<package>` / <br> `name=<package-1>,<package-2>,<etc>` |  filters by package name (substring match) |
 | **installation reason** | `reason=explicit` / `reason=dependencies` | filters packages by installation reason: explicitly installed or installed as a dependency |
 | **size** | `size=<value>` | filters by package size on disk. supports exact values (`10MB`), ranges (`10MB:1GB`), and open-ended ranges (`:500KB`, `1GB:`) |
@@ -206,7 +206,7 @@ output format:
 ```json
 [
   {
-    "timestamp": "2025-02-26T16:33:47Z",
+    "timestamp": 174058762,
     "name": "sqlite",
     "reason": "dependency",
     "size": 21074944,

--- a/cmd/yaylog/main.go
+++ b/cmd/yaylog/main.go
@@ -31,13 +31,13 @@ func mainWithConfig(configProvider config.ConfigProvider) error {
 	isInteractive := term.IsTerminal(int(os.Stdout.Fd())) && !cfg.DisableProgress
 	var wg sync.WaitGroup
 
-	pipeline := []PipelinePhase{
+	pipelinePhases := []PipelinePhase{
 		{"Calculating reverse dependencies", pkgdata.CalculateReverseDependencies, isInteractive, &wg},
 		{"Filtering", pipeline.PreprocessFiltering, isInteractive, &wg},
 		{"Sorting", pkgdata.SortPackages, isInteractive, &wg},
 	}
 
-	for _, phase := range pipeline {
+	for _, phase := range pipelinePhases {
 		packages, err = phase.Run(cfg, packages)
 		if err != nil {
 			return err

--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -8,8 +8,8 @@ import (
 )
 
 func (o *OutputManager) renderJson(pkgs []pkgdata.PackageInfo, fields []consts.FieldType) {
-	if !isAllFields(fields) {
-		pkgs = selectJsonFields(pkgs, fields)
+	if isAllFields, uniqueFields := getUniqueFields(fields); isAllFields {
+		pkgs = selectJsonFields(pkgs, uniqueFields)
 	}
 
 	jsonOutput, err := json.MarshalIndent(pkgs, "", "  ")
@@ -21,20 +21,18 @@ func (o *OutputManager) renderJson(pkgs []pkgdata.PackageInfo, fields []consts.F
 }
 
 // quick check to verify if we should select fields at all
-func isAllFields(fields []consts.FieldType) bool {
-	if len(fields) != len(consts.ValidFields) {
-		return false
-	}
-
+func getUniqueFields(fields []consts.FieldType) (bool, []consts.FieldType) {
+	fieldSet := make(map[consts.FieldType]bool, len(fields))
 	for _, field := range fields {
-		for _, validField := range consts.ValidFields {
-			if field != validField {
-				return false
-			}
-		}
+		fieldSet[field] = true
 	}
 
-	return true
+	uniqueFields := make([]consts.FieldType, 0, len(fieldSet))
+	for field := range fieldSet {
+		uniqueFields = append(uniqueFields, field)
+	}
+
+	return len(fieldSet) != len(consts.ValidFields), uniqueFields
 }
 
 func selectJsonFields(

--- a/internal/display/render_table.go
+++ b/internal/display/render_table.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"text/tabwriter"
+	"time"
 	"yaylog/internal/consts"
 	"yaylog/internal/pkgdata"
 )
@@ -109,7 +110,9 @@ func getTableValue(pkg pkgdata.PackageInfo, field consts.FieldType, ctx tableCon
 
 // use time as parameter
 func formatDate(pkg pkgdata.PackageInfo, ctx tableContext) string {
-	return pkg.Timestamp.Format(ctx.DateFormat)
+	// return pkg.Timestamp.Format(ctx.DateFormat)
+	timestamp := time.Unix(pkg.Timestamp, 0)
+	return timestamp.Format(ctx.DateFormat)
 }
 
 func formatPackageList(packages []string) string {

--- a/internal/pipeline/condition_filters.go
+++ b/internal/pipeline/condition_filters.go
@@ -7,6 +7,12 @@ import (
 	"yaylog/internal/pkgdata"
 )
 
+type RangeFilter struct {
+	Start   int64
+	End     int64
+	IsExact bool
+}
+
 func newBaseCondition(filterType consts.FieldType) FilterCondition {
 	return FilterCondition{
 		PhaseName: "Filtering by " + string(filterType),
@@ -51,40 +57,40 @@ func NewPackageCondition(fieldType consts.FieldType, targets []string) (FilterCo
 	return conditionFilter, nil
 }
 
-func NewDateCondition(dateFilter DateFilter) FilterCondition {
-	startDate, endDate, isExact := dateFilter.StartDate, dateFilter.EndDate, dateFilter.IsExact
+func NewDateCondition(dateFilter RangeFilter) FilterCondition {
+	start, end, isExact := dateFilter.Start, dateFilter.End, dateFilter.IsExact
 	condition := newBaseCondition(consts.FieldDate)
 
 	if isExact {
 		condition.Filter = func(pkg PackageInfo) bool {
-			return pkgdata.FilterByDate(pkg, startDate)
+			return pkgdata.FilterByDate(pkg, start)
 		}
 
 		return condition
 	}
 
-	adjustedEndDate := endDate.Add(24 * time.Hour) // ensure full date range
+	adjustedEnd := end + int64(time.Hour*24/time.Second) // ensure full date range
 	condition.Filter = func(pkg PackageInfo) bool {
-		return pkgdata.FilterByDateRange(pkg, startDate, adjustedEndDate)
+		return pkgdata.FilterByDateRange(pkg, start, adjustedEnd)
 	}
 
 	return condition
 }
 
-func NewSizeCondition(sizeFilter SizeFilter) FilterCondition {
-	startSize, endSize, isExact := sizeFilter.StartSize, sizeFilter.EndSize, sizeFilter.IsExact
+func NewSizeCondition(sizeFilter RangeFilter) FilterCondition {
+	start, end, isExact := sizeFilter.Start, sizeFilter.End, sizeFilter.IsExact
 	condition := newBaseCondition(consts.FieldSize)
 
 	if isExact {
 		condition.Filter = func(pkg PackageInfo) bool {
-			return pkgdata.FilterBySize(pkg, startSize)
+			return pkgdata.FilterBySize(pkg, start)
 		}
 
 		return condition
 	}
 
 	condition.Filter = func(pkg PackageInfo) bool {
-		return pkgdata.FilterBySizeRange(pkg, startSize, endSize)
+		return pkgdata.FilterBySizeRange(pkg, start, end)
 	}
 
 	return condition

--- a/internal/pipeline/date.go
+++ b/internal/pipeline/date.go
@@ -8,13 +8,13 @@ import (
 	"yaylog/internal/consts"
 )
 
-func parseDateFilter(dateFilterInput string) (RangeFilter, error) {
+func parseDateFilter(dateFilterInput string) (RangeSelector, error) {
 	if dateFilterInput == "" {
-		return RangeFilter{}, nil
+		return RangeSelector{}, nil
 	}
 
 	if dateFilterInput == ":" {
-		return RangeFilter{}, fmt.Errorf("invalid date filter: ':' must be accompanied by a date")
+		return RangeSelector{}, fmt.Errorf("invalid date filter: ':' must be accompanied by a date")
 	}
 
 	pattern := `^(\d{4}-\d{2}-\d{2})?(?::(\d{4}-\d{2}-\d{2})?)?$`
@@ -23,20 +23,22 @@ func parseDateFilter(dateFilterInput string) (RangeFilter, error) {
 	isExact := !strings.Contains(dateFilterInput, ":")
 
 	if matches == nil {
-		return RangeFilter{}, fmt.Errorf("invalid date filter format: %q", dateFilterInput)
+		return RangeSelector{}, fmt.Errorf("invalid date filter format: %q", dateFilterInput)
 	}
 
 	start, err := parseDateMatch(matches[1], 0)
 	if err != nil {
-		return RangeFilter{}, err
+		return RangeSelector{}, err
 	}
 
 	end, err := parseDateMatch(matches[2], time.Now().Unix())
 	if err != nil {
-		return RangeFilter{}, err
+		return RangeSelector{}, err
 	}
 
-	return RangeFilter{
+	end += int64(time.Hour * 24 / time.Second)
+
+	return RangeSelector{
 		start,
 		end,
 		isExact,
@@ -60,7 +62,7 @@ func parseValidDate(dateInput string) (int64, error) {
 	return parsedDate.Unix(), nil
 }
 
-func validateDateFilter(dateFilter RangeFilter) error {
+func validateDateFilter(dateFilter RangeSelector) error {
 	if dateFilter.Start > 0 && dateFilter.End > 0 {
 		if dateFilter.Start > dateFilter.End {
 			return fmt.Errorf("Error invalid date range. The start date cannot be after the end date")

--- a/internal/pipeline/date.go
+++ b/internal/pipeline/date.go
@@ -8,19 +8,13 @@ import (
 	"yaylog/internal/consts"
 )
 
-type DateFilter struct {
-	StartDate time.Time
-	EndDate   time.Time
-	IsExact   bool
-}
-
-func parseDateFilter(dateFilterInput string) (DateFilter, error) {
+func parseDateFilter(dateFilterInput string) (RangeFilter, error) {
 	if dateFilterInput == "" {
-		return DateFilter{}, nil
+		return RangeFilter{}, nil
 	}
 
 	if dateFilterInput == ":" {
-		return DateFilter{}, fmt.Errorf("invalid date filter: ':' must be accompanied by a date")
+		return RangeFilter{}, fmt.Errorf("invalid date filter: ':' must be accompanied by a date")
 	}
 
 	pattern := `^(\d{4}-\d{2}-\d{2})?(?::(\d{4}-\d{2}-\d{2})?)?$`
@@ -29,27 +23,27 @@ func parseDateFilter(dateFilterInput string) (DateFilter, error) {
 	isExact := !strings.Contains(dateFilterInput, ":")
 
 	if matches == nil {
-		return DateFilter{}, fmt.Errorf("invalid date filter format: %q", dateFilterInput)
+		return RangeFilter{}, fmt.Errorf("invalid date filter format: %q", dateFilterInput)
 	}
 
-	startDate, err := parseDateMatch(matches[1], time.Time{})
+	start, err := parseDateMatch(matches[1], 0)
 	if err != nil {
-		return DateFilter{}, err
+		return RangeFilter{}, err
 	}
 
-	endDate, err := parseDateMatch(matches[2], time.Now())
+	end, err := parseDateMatch(matches[2], time.Now().Unix())
 	if err != nil {
-		return DateFilter{}, err
+		return RangeFilter{}, err
 	}
 
-	return DateFilter{
-		startDate,
-		endDate,
+	return RangeFilter{
+		start,
+		end,
 		isExact,
 	}, nil
 }
 
-func parseDateMatch(dateInput string, defaultDate time.Time) (time.Time, error) {
+func parseDateMatch(dateInput string, defaultDate int64) (int64, error) {
 	if dateInput == "" {
 		return defaultDate, nil
 	}
@@ -57,18 +51,18 @@ func parseDateMatch(dateInput string, defaultDate time.Time) (time.Time, error) 
 	return parseValidDate(dateInput)
 }
 
-func parseValidDate(dateInput string) (time.Time, error) {
+func parseValidDate(dateInput string) (int64, error) {
 	parsedDate, err := time.Parse(consts.DateOnlyFormat, dateInput)
 	if err != nil {
-		return time.Time{}, err
+		return 0, err
 	}
 
-	return parsedDate, nil
+	return parsedDate.Unix(), nil
 }
 
-func validateDateFilter(dateFilter DateFilter) error {
-	if !dateFilter.StartDate.IsZero() && !dateFilter.EndDate.IsZero() {
-		if dateFilter.StartDate.After(dateFilter.EndDate) {
+func validateDateFilter(dateFilter RangeFilter) error {
+	if dateFilter.Start > 0 && dateFilter.End > 0 {
+		if dateFilter.Start > dateFilter.End {
 			return fmt.Errorf("Error invalid date range. The start date cannot be after the end date")
 		}
 	}

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -77,7 +77,7 @@ func parsePackageFilterCondition(
 	}
 
 	targetList := strings.Split(targetListInput, ",")
-	return NewPackageCondition(fieldType, targetList)
+	return newPackageCondition(fieldType, targetList)
 }
 
 func parseReasonFilterCondition(installReason string) (FilterCondition, error) {
@@ -85,7 +85,7 @@ func parseReasonFilterCondition(installReason string) (FilterCondition, error) {
 		return FilterCondition{}, fmt.Errorf("invalid install reason filter: %s", installReason)
 	}
 
-	return NewReasonCondition(installReason), nil
+	return newReasonCondition(installReason), nil
 }
 
 func parseDateFilterCondition(value string) (FilterCondition, error) {
@@ -98,7 +98,7 @@ func parseDateFilterCondition(value string) (FilterCondition, error) {
 		return pkgdata.FilterCondition{}, err
 	}
 
-	return NewDateCondition(dateFilter), nil
+	return newDateCondition(dateFilter), nil
 }
 
 func parseSizeFilterCondition(value string) (FilterCondition, error) {
@@ -111,5 +111,5 @@ func parseSizeFilterCondition(value string) (FilterCondition, error) {
 		return FilterCondition{}, err
 	}
 
-	return NewSizeCondition(sizeFilter), nil
+	return newSizeCondition(sizeFilter), nil
 }

--- a/internal/pipeline/size.go
+++ b/internal/pipeline/size.go
@@ -9,19 +9,13 @@ import (
 	"yaylog/internal/consts"
 )
 
-type SizeFilter struct {
-	StartSize int64
-	EndSize   int64
-	IsExact   bool
-}
-
-func parseSizeFilter(sizeFilterInput string) (SizeFilter, error) {
+func parseSizeFilter(sizeFilterInput string) (RangeFilter, error) {
 	if sizeFilterInput == "" {
-		return SizeFilter{}, nil
+		return RangeFilter{}, nil
 	}
 
 	if sizeFilterInput == ":" {
-		return SizeFilter{}, fmt.Errorf("invalid size filter: ':' must be accompanied by a value")
+		return RangeFilter{}, fmt.Errorf("invalid size filter: ':' must be accompanied by a value")
 	}
 
 	// valid size format: "10MB", "5GB:", ":20KB", "1.5MB:2GB" (value + unit, optional range)
@@ -31,22 +25,22 @@ func parseSizeFilter(sizeFilterInput string) (SizeFilter, error) {
 	isExact := !strings.Contains(sizeFilterInput, ":")
 
 	if matches == nil {
-		return SizeFilter{}, fmt.Errorf("invalid size filter format: %q", sizeFilterInput)
+		return RangeFilter{}, fmt.Errorf("invalid size filter format: %q", sizeFilterInput)
 	}
 
-	startSize, err := parseSizeMatch(matches[1], matches[2], 0)
+	start, err := parseSizeMatch(matches[1], matches[2], 0)
 	if err != nil {
-		return SizeFilter{}, err
+		return RangeFilter{}, err
 	}
 
-	endSize, err := parseSizeMatch(matches[3], matches[4], math.MaxInt64)
+	end, err := parseSizeMatch(matches[3], matches[4], math.MaxInt64)
 	if err != nil {
-		return SizeFilter{}, err
+		return RangeFilter{}, err
 	}
 
-	return SizeFilter{
-		startSize,
-		endSize,
+	return RangeFilter{
+		start,
+		end,
 		isExact,
 	}, nil
 }
@@ -83,9 +77,9 @@ func parseSizeInBytes(valueInput string, unitInput string) (sizeInBytes int64, e
 	return sizeInBytes, nil
 }
 
-func validateSizeFilter(sizeFilter SizeFilter) error {
-	if sizeFilter.StartSize > 0 && sizeFilter.EndSize > 0 {
-		if sizeFilter.StartSize > sizeFilter.EndSize {
+func validateSizeFilter(sizeFilter RangeFilter) error {
+	if sizeFilter.Start > 0 && sizeFilter.End > 0 {
+		if sizeFilter.Start > sizeFilter.End {
 			return fmt.Errorf("Error: invalid size range. Start size cannot be greater than the end size")
 		}
 	}

--- a/internal/pipeline/size.go
+++ b/internal/pipeline/size.go
@@ -9,13 +9,13 @@ import (
 	"yaylog/internal/consts"
 )
 
-func parseSizeFilter(sizeFilterInput string) (RangeFilter, error) {
+func parseSizeFilter(sizeFilterInput string) (RangeSelector, error) {
 	if sizeFilterInput == "" {
-		return RangeFilter{}, nil
+		return RangeSelector{}, nil
 	}
 
 	if sizeFilterInput == ":" {
-		return RangeFilter{}, fmt.Errorf("invalid size filter: ':' must be accompanied by a value")
+		return RangeSelector{}, fmt.Errorf("invalid size filter: ':' must be accompanied by a value")
 	}
 
 	// valid size format: "10MB", "5GB:", ":20KB", "1.5MB:2GB" (value + unit, optional range)
@@ -25,20 +25,20 @@ func parseSizeFilter(sizeFilterInput string) (RangeFilter, error) {
 	isExact := !strings.Contains(sizeFilterInput, ":")
 
 	if matches == nil {
-		return RangeFilter{}, fmt.Errorf("invalid size filter format: %q", sizeFilterInput)
+		return RangeSelector{}, fmt.Errorf("invalid size filter format: %q", sizeFilterInput)
 	}
 
 	start, err := parseSizeMatch(matches[1], matches[2], 0)
 	if err != nil {
-		return RangeFilter{}, err
+		return RangeSelector{}, err
 	}
 
 	end, err := parseSizeMatch(matches[3], matches[4], math.MaxInt64)
 	if err != nil {
-		return RangeFilter{}, err
+		return RangeSelector{}, err
 	}
 
-	return RangeFilter{
+	return RangeSelector{
 		start,
 		end,
 		isExact,
@@ -77,7 +77,7 @@ func parseSizeInBytes(valueInput string, unitInput string) (sizeInBytes int64, e
 	return sizeInBytes, nil
 }
 
-func validateSizeFilter(sizeFilter RangeFilter) error {
+func validateSizeFilter(sizeFilter RangeSelector) error {
 	if sizeFilter.Start > 0 && sizeFilter.End > 0 {
 		if sizeFilter.Start > sizeFilter.End {
 			return fmt.Errorf("Error: invalid size range. Start size cannot be greater than the end size")

--- a/internal/pkgdata/fetch.go
+++ b/internal/pkgdata/fetch.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 )
 
 const (
@@ -172,7 +171,7 @@ func applyField(pkg *PackageInfo, field string, value string) error {
 			return fmt.Errorf("invalid install date value %q: %w", value, err)
 		}
 
-		pkg.Timestamp = time.Unix(installDate, 0)
+		pkg.Timestamp = installDate
 
 	case fieldVersion:
 		pkg.Version = value

--- a/internal/pkgdata/filters.go
+++ b/internal/pkgdata/filters.go
@@ -62,12 +62,14 @@ func roundSizeInBytes(num int64) int64 {
 	return num / scaleFactor
 }
 
+// TODO: let's pre-round the inputs outside of these functions
 func FilterBySize(pkg PackageInfo, targetSize int64) bool {
 	return roundSizeInBytes(pkg.Size) == roundSizeInBytes(targetSize)
 }
 
 func FilterBySizeRange(pkg PackageInfo, startSize int64, endSize int64) bool {
-	return pkg.Size >= startSize && pkg.Size <= endSize
+	roundedSize := roundSizeInBytes(pkg.Size)
+	return !(roundedSize < roundSizeInBytes(startSize) || roundedSize > roundSizeInBytes(endSize))
 }
 
 func FilterByStrings(pkgString string, targetStrings []string) bool {

--- a/internal/pkgdata/filters.go
+++ b/internal/pkgdata/filters.go
@@ -39,14 +39,16 @@ func FilterDependencies(pkg PackageInfo) bool {
 	return pkg.Reason == "dependency"
 }
 
-// filters for packages installed on specific date
-func FilterByDate(pkg PackageInfo, date time.Time) bool {
-	return pkg.Timestamp.Year() == date.Year() && pkg.Timestamp.YearDay() == date.YearDay()
+// // filters for packages installed on specific date
+func FilterByDate(pkg PackageInfo, date int64) bool {
+	pkgDate := time.Unix(pkg.Timestamp, 0)
+	targetDate := time.Unix(date, 0)
+	return pkgDate.Year() == targetDate.Year() && pkgDate.YearDay() == targetDate.YearDay()
 }
 
 // inclusive
-func FilterByDateRange(pkg PackageInfo, startDate time.Time, endDate time.Time) bool {
-	return !(pkg.Timestamp.Before(startDate) || pkg.Timestamp.After(endDate))
+func FilterByDateRange(pkg PackageInfo, start int64, end int64) bool {
+	return !(pkg.Timestamp < start || pkg.Timestamp > end)
 }
 
 func roundSizeInBytes(num int64) int64 {
@@ -60,8 +62,8 @@ func roundSizeInBytes(num int64) int64 {
 	return num / scaleFactor
 }
 
-func FilterBySize(pkg PackageInfo, size int64) bool {
-	return roundSizeInBytes(pkg.Size) == roundSizeInBytes(size)
+func FilterBySize(pkg PackageInfo, targetSize int64) bool {
+	return roundSizeInBytes(pkg.Size) == roundSizeInBytes(targetSize)
 }
 
 func FilterBySizeRange(pkg PackageInfo, startSize int64, endSize int64) bool {

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -1,8 +1,7 @@
 package pkgdata
 
-import "time"
-
-type BasePackageInfo struct {
+type PackageInfo struct {
+	Timestamp  int64    `json:"timestamp,omitempty"`
 	Name       string   `json:"name,omitempty"`
 	Reason     string   `json:"reason,omitempty"`  // "explicit" or "dependency"
 	Size       int64    `json:"size,omitempty"`    // package size in bytes
@@ -12,15 +11,4 @@ type BasePackageInfo struct {
 	Provides   []string `json:"provides,omitempty"`
 	Conflicts  []string `json:"conflicts,omitempty"`
 	Arch       string   `json:"arch,omitempty"`
-}
-
-// info about a single installed package
-type PackageInfo struct {
-	Timestamp time.Time
-	BasePackageInfo
-}
-
-type PackageInfoJson struct {
-	Timestamp *time.Time `json:"timestamp,omitempty"`
-	BasePackageInfo
 }

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -17,7 +17,7 @@ func alphabeticalComparator(a PackageInfo, b PackageInfo) bool {
 }
 
 func dateComparator(a PackageInfo, b PackageInfo) bool {
-	return a.Timestamp.Before(b.Timestamp)
+	return a.Timestamp < b.Timestamp
 }
 
 func sizeDecComparator(a PackageInfo, b PackageInfo) bool {


### PR DESCRIPTION
We've changed Timestamps on PackageData structs from Time entities to int64s. This reduces the bloat of the PackageData structs, improves the speed of filtering comparisons, improves the speed of sorting, and allows us to merge similar logic between date and size data manipulation.

Addresses #111.