### PR TITLE
Feature: Add license field

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,45 +191,52 @@ short-flag filters and long-flag filters can be combined.
 - `provides` - list of alternative package names or shared libraries provided by package (output can be long)
 - `conficts` - list of packages that conflict, or cause problems, with the package
 - `arch` - architecture the package was built for (e.g., x86_64, aarch64, any)
+- `license` - package software license
 
 ### JSON output
 the `--json` flag outputs the package data as structured JSON instead of a table. this can be useful for scripts or automation.
 
 example:
 ```bash
-yaylog -f name=sqlite --all-columns --json
+yaylog -f name=tinysparql --all-columns --json
 ```
 
-`sqlite` is one of the few packages that actually has all the fields populated.
+`tinysparql` is one of the few packages that actually has all the fields populated.
 
 output format:
 ```json
 [
   {
-    "timestamp": 174058762,
-    "name": "sqlite",
+    "timestamp": 1739294218,
+    "name": "tinysparql",
     "reason": "dependency",
-    "size": 21074944,
-    "version": "3.48.0-2",
+    "size": 4385422,
+    "version": "3.8.2-2",
     "depends": [
-      "readline",
-      "zlib",
-      "glibc"
+      "avahi",
+      "gcc-libs",
+      "glib2",
+      "glibc",
+      "icu",
+      "json-glib",
+      "libsoup3",
+      "libstemmer",
+      "libxml2",
+      "sqlite"
     ],
     "requiredBy": [
-      "docker",
-      "gnupg",
-      "libsoup3",
-      "nss",
-      "openslide",
-      "tinysparql",
-      "util-linux-libs"
+      "gtk3",
+      "gtk4"
     ],
     "provides": [
-      "sqlite3=3.48.0",
-      "libsqlite3.so=0-64"
+      "tracker3=3.8.2",
+      "libtinysparql-3.0.so=0-64"
     ],
-    "arch": "x86_64"
+    "conflicts": [
+      "tracker3<=3.7.3-2"
+    ],
+    "arch": "aarch64",
+    "license": "GPL-2.0-or-later"
   }
 ]
 ```

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -58,6 +58,7 @@ func PrintHelp() {
 	fmt.Println("  provides     List of alternative package names or shared libraries provided (output can be long)")
 	fmt.Println("  conflicts    List of packages that conflict, or cause problems, with the package")
 	fmt.Println("  arch         Architecture the package was built for")
+	fmt.Println("  license      Package software license")
 
 	fmt.Println("\nDeprecated Legacy Options (Use --filter Instead):")
 	fmt.Println("  -e, --explicit              (Deprecated) Show only explicitly installed packages")

--- a/internal/consts/columns.go
+++ b/internal/consts/columns.go
@@ -13,6 +13,7 @@ const (
 	provides   = "provides"
 	conflicts  = "conflicts"
 	arch       = "arch"
+	license    = "license"
 )
 
 const (
@@ -26,6 +27,7 @@ const (
 	FieldProvides   FieldType = provides
 	FieldConflicts  FieldType = conflicts
 	FieldArch       FieldType = arch
+	FieldLicense    FieldType = license
 )
 
 var FieldTypeLookup = map[string]FieldType{
@@ -48,6 +50,7 @@ var FieldTypeLookup = map[string]FieldType{
 	provides:   FieldProvides,
 	conflicts:  FieldConflicts,
 	arch:       FieldArch,
+	license:    FieldLicense,
 }
 
 var (
@@ -68,5 +71,6 @@ var (
 		FieldProvides,
 		FieldConflicts,
 		FieldArch,
+		FieldLicense,
 	}
 )

--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -72,6 +72,8 @@ func getJsonValues(pkg pkgdata.PackageInfo, fields []consts.FieldType) pkgdata.P
 			filteredPackage.Conflicts = pkg.Conflicts
 		case consts.FieldArch:
 			filteredPackage.Arch = pkg.Arch
+		case consts.FieldLicense:
+			filteredPackage.License = pkg.License
 		}
 	}
 

--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -1,6 +1,7 @@
 package display
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"yaylog/internal/consts"
@@ -12,12 +13,16 @@ func (o *OutputManager) renderJson(pkgs []pkgdata.PackageInfo, fields []consts.F
 		pkgs = selectJsonFields(pkgs, uniqueFields)
 	}
 
-	jsonOutput, err := json.MarshalIndent(pkgs, "", "  ")
-	if err != nil {
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false) // disable escaping of characters like `<`, `>`, perhaps this should be a user defined option
+	encoder.SetIndent("", "  ")
+
+	if err := encoder.Encode(pkgs); err != nil {
 		o.writeLine(fmt.Sprintf("Error genereating JSON output: %v", err))
 	}
 
-	o.writeLine(string(jsonOutput))
+	o.writeLine(buffer.String())
 }
 
 // quick check to verify if we should select fields at all

--- a/internal/display/render_table.go
+++ b/internal/display/render_table.go
@@ -25,6 +25,7 @@ var columnHeaders = map[consts.FieldType]string{
 	consts.FieldProvides:   "PROVIDES",
 	consts.FieldConflicts:  "CONFLICTS",
 	consts.FieldArch:       "ARCH",
+	consts.FieldLicense:    "LICENSE",
 }
 
 // displays data in tab format
@@ -103,6 +104,8 @@ func getTableValue(pkg pkgdata.PackageInfo, field consts.FieldType, ctx tableCon
 		return formatPackageList(pkg.Conflicts)
 	case consts.FieldArch:
 		return pkg.Arch
+	case consts.FieldLicense:
+		return pkg.License
 	default:
 		return ""
 	}

--- a/internal/pkgdata/fetch.go
+++ b/internal/pkgdata/fetch.go
@@ -22,6 +22,7 @@ const (
 	fieldProvides    = "%PROVIDES%"
 	fieldConflicts   = "%CONFLICTS%"
 	fieldArch        = "%ARCH%"
+	fieldLicense     = "%LICENSE%"
 
 	pacmanDbPath = "/var/lib/pacman/local"
 )
@@ -131,7 +132,8 @@ func parseDescFile(descPath string) (PackageInfo, error) {
 			fieldDepends,
 			fieldProvides,
 			fieldConflicts,
-			fieldArch:
+			fieldArch,
+			fieldLicense:
 			currentField = line
 		case "":
 			currentField = "" // reset if line is blank
@@ -196,6 +198,9 @@ func applyField(pkg *PackageInfo, field string, value string) error {
 
 	case fieldArch:
 		pkg.Arch = value
+
+	case fieldLicense:
+		pkg.License = value
 
 	default:
 		// ignore unknown fields

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -11,4 +11,5 @@ type PackageInfo struct {
 	Provides   []string `json:"provides,omitempty"`
 	Conflicts  []string `json:"conflicts,omitempty"`
 	Arch       string   `json:"arch,omitempty"`
+	License    string   `json:"license,omitempty"`
 }

--- a/yaylog.1
+++ b/yaylog.1
@@ -151,6 +151,9 @@ Specify a comma-separated list of columns to display. Available columns:
 .IP
 .B arch
 : Architecture the package was built for. 
+.IP
+.B license
+: Package software license.
 .TP
 .B \-\-all-columns
 Show all available columns.


### PR DESCRIPTION
Users can now pull package licenses with `yaylog --add-columns license`, `yaylog --columns license`, and `yaylog --all-columns`.

```bash
> yaylog --columns name,license -f name=tinysparql
NAME        LICENSE
tinysparql  GPL-2.0-or-later
```

Addresses #98 