### PR TITLE
Feature: Add URL field

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ because yay is my preferred AUR helper and the name has a good flow.
 - [x] asynchronous progress bar
 - [x] channel-based aggregation
 - [x] concurrent sorting
-- [x] search by text input
-- [x] package versions
+- [x] filter by package name
+- [x] package version field
 - [x] filter by date range
 - [x] concurrent file reading (2x speed boost)
 - [x] remove expac as a dependency (3x speed boost)
@@ -65,12 +65,12 @@ because yay is my preferred AUR helper and the name has a good flow.
 - [x] remove go as a dependency
 - [x] filter by range of size on disk
 - [x] user defined columns
-- [x] dependencies of each package
+- [x] dependencies of each package (dependency field)
 - [x] reverse-dependencies of each package (required-by field)
-- [ ] package descriptions
-- [ ] package URLs
-- [x] package architecture
-- [x] package conflicts
+- [ ] package descriptions field
+- [x] package URL field
+- [x] package architectur field
+- [x] package conflicts field
 - [x] conflicts filter
 - [ ] name exclusion filter
 - [ ] self-referencing column
@@ -85,10 +85,14 @@ because yay is my preferred AUR helper and the name has a good flow.
 - [x] config dependency injection for testing
 - [ ] required-by count sort
 - [x] metaflag for all filters
+- [x] license field
 - [ ] XML output
 - [ ] short-args for filters
+- [ ] license sort
 - [x] architecture filter
 - [ ] dependency count sort
+- [ ] license filter
+- [ ] optional dependency field
 
 ## installation
 
@@ -192,6 +196,7 @@ short-flag filters and long-flag filters can be combined.
 - `conficts` - list of packages that conflict, or cause problems, with the package
 - `arch` - architecture the package was built for (e.g., x86_64, aarch64, any)
 - `license` - package software license
+- `url` - the URL of the official site of the software being packaged
 
 ### JSON output
 the `--json` flag outputs the package data as structured JSON instead of a table. this can be useful for scripts or automation.
@@ -236,7 +241,8 @@ output format:
       "tracker3<=3.7.3-2"
     ],
     "arch": "aarch64",
-    "license": "GPL-2.0-or-later"
+    "license": "GPL-2.0-or-later",
+    "url": "https://tinysparql.org/"
   }
 ]
 ```

--- a/internal/config/help.go
+++ b/internal/config/help.go
@@ -59,6 +59,7 @@ func PrintHelp() {
 	fmt.Println("  conflicts    List of packages that conflict, or cause problems, with the package")
 	fmt.Println("  arch         Architecture the package was built for")
 	fmt.Println("  license      Package software license")
+	fmt.Println("  url          URL of the official site of the software being packaged")
 
 	fmt.Println("\nDeprecated Legacy Options (Use --filter Instead):")
 	fmt.Println("  -e, --explicit              (Deprecated) Show only explicitly installed packages")

--- a/internal/consts/columns.go
+++ b/internal/consts/columns.go
@@ -14,6 +14,7 @@ const (
 	conflicts  = "conflicts"
 	arch       = "arch"
 	license    = "license"
+	url        = "url"
 )
 
 const (
@@ -28,6 +29,7 @@ const (
 	FieldConflicts  FieldType = conflicts
 	FieldArch       FieldType = arch
 	FieldLicense    FieldType = license
+	FieldUrl        FieldType = url
 )
 
 var FieldTypeLookup = map[string]FieldType{
@@ -51,6 +53,7 @@ var FieldTypeLookup = map[string]FieldType{
 	conflicts:  FieldConflicts,
 	arch:       FieldArch,
 	license:    FieldLicense,
+	url:        FieldUrl,
 }
 
 var (
@@ -72,5 +75,6 @@ var (
 		FieldConflicts,
 		FieldArch,
 		FieldLicense,
+		FieldUrl,
 	}
 )

--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -79,6 +79,8 @@ func getJsonValues(pkg pkgdata.PackageInfo, fields []consts.FieldType) pkgdata.P
 			filteredPackage.Arch = pkg.Arch
 		case consts.FieldLicense:
 			filteredPackage.License = pkg.License
+		case consts.FieldUrl:
+			filteredPackage.Url = pkg.Url
 		}
 	}
 

--- a/internal/display/render_table.go
+++ b/internal/display/render_table.go
@@ -26,6 +26,7 @@ var columnHeaders = map[consts.FieldType]string{
 	consts.FieldConflicts:  "CONFLICTS",
 	consts.FieldArch:       "ARCH",
 	consts.FieldLicense:    "LICENSE",
+	consts.FieldUrl:        "URL",
 }
 
 // displays data in tab format
@@ -106,6 +107,8 @@ func getTableValue(pkg pkgdata.PackageInfo, field consts.FieldType, ctx tableCon
 		return pkg.Arch
 	case consts.FieldLicense:
 		return pkg.License
+	case consts.FieldUrl:
+		return pkg.Url
 	default:
 		return ""
 	}
@@ -113,7 +116,6 @@ func getTableValue(pkg pkgdata.PackageInfo, field consts.FieldType, ctx tableCon
 
 // use time as parameter
 func formatDate(pkg pkgdata.PackageInfo, ctx tableContext) string {
-	// return pkg.Timestamp.Format(ctx.DateFormat)
 	timestamp := time.Unix(pkg.Timestamp, 0)
 	return timestamp.Format(ctx.DateFormat)
 }

--- a/internal/pkgdata/fetch.go
+++ b/internal/pkgdata/fetch.go
@@ -23,6 +23,7 @@ const (
 	fieldConflicts   = "%CONFLICTS%"
 	fieldArch        = "%ARCH%"
 	fieldLicense     = "%LICENSE%"
+	fieldUrl         = "%URL%"
 
 	pacmanDbPath = "/var/lib/pacman/local"
 )
@@ -133,7 +134,8 @@ func parseDescFile(descPath string) (PackageInfo, error) {
 			fieldProvides,
 			fieldConflicts,
 			fieldArch,
-			fieldLicense:
+			fieldLicense,
+			fieldUrl:
 			currentField = line
 		case "":
 			currentField = "" // reset if line is blank
@@ -201,6 +203,9 @@ func applyField(pkg *PackageInfo, field string, value string) error {
 
 	case fieldLicense:
 		pkg.License = value
+
+	case fieldUrl:
+		pkg.Url = value
 
 	default:
 		// ignore unknown fields

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -12,4 +12,5 @@ type PackageInfo struct {
 	Conflicts  []string `json:"conflicts,omitempty"`
 	Arch       string   `json:"arch,omitempty"`
 	License    string   `json:"license,omitempty"`
+	Url        string   `json:"url,omitempty"`
 }

--- a/yaylog.1
+++ b/yaylog.1
@@ -1,5 +1,5 @@
 .\" Man page for yaylog
-.TH yaylog 1 "March 2025" "yaylog 3.19.0" "User Commands"
+.TH yaylog 1 "March 2025" "yaylog 3.27.0" "User Commands"
 .SH NAME
 yaylog \- List and filter installed packages on Arch-based systems.
 .SH SYNOPSIS
@@ -100,6 +100,7 @@ For example, to filter all explicitly installed packages larger than 100MB:
 .EX
 yaylog -f reason=explicit -f size=100MB:
 .EE
+
 .TP
 .B \-\-sort <mode>
 Sort results by the specified mode. Available modes:
@@ -154,6 +155,9 @@ Specify a comma-separated list of columns to display. Available columns:
 .IP
 .B license
 : Package software license.
+.IP
+.B url
+: URL of the official site of the software being packaged.
 .TP
 .B \-\-all-columns
 Show all available columns.


### PR DESCRIPTION
Users can now pull package URLs with `yaylog --add-columns url`, `yaylog --columns url`, and `yaylog --all-columns`.

```bash
> yaylog --columns name,url
NAME                           URL
perl-class-method-modifiers    https://search.cpan.org/dist/Class-Method-Modifiers
perl-data-optlist              https://metacpan.org/release/Data-OptList
perl-devel-globaldestruction   https://search.cpan.org/dist/Devel-GlobalDestruction
perl-import-into               https://search.cpan.org/dist/Import-Into
perl-module-runtime            https://search.cpan.org/dist/Module-Runtime/
perl-parallel-forkmanager      https://metacpan.org/release/Parallel-ForkManager
perl-moo                       https://metacpan.org/release/Moo
perl-params-util               https://metacpan.org/release/Params-Util
perl-regexp-common             https://metacpan.org/release/Regexp-Common
perl-role-tiny                 https://search.cpan.org/dist/Role-Tiny/
perl-sub-exporter              https://metacpan.org/release/Sub-Exporter
perl-sub-exporter-progressive  https://search.cpan.org/dist/Sub-Exporter-Progressive
perl-sub-install               https://metacpan.org/release/Sub-Install
perl-sub-quote                 https://search.cpan.org/dist/Sub-Quote
cloc                           https://github.com/AlDanial/cloc
asciinema                      https://asciinema.org
rbenv                          https://github.com/rbenv/rbenv
ruby-build                     https://github.com/rbenv/ruby-build
src-cli-bin                    https://github.com/sourcegraph/src-cli
yaylog                         https://github.com/Zweih/yaylog
```

Addresses #109. 