### PR TITLE
Feature: Chunked channel filtering

### DIFF
--- a/internal/pipeline/condition_filters.go
+++ b/internal/pipeline/condition_filters.go
@@ -12,9 +12,9 @@ type RangeSelector struct {
 	IsExact bool
 }
 
-type ExactFilter func(pkg pkgdata.PkgInfo, target int64) bool
+type ExactFilter func(pkg *PkgInfo, target int64) bool
 
-type RangeFilter func(pkg pkgdata.PkgInfo, start int64, end int64) bool
+type RangeFilter func(pkg *PkgInfo, start int64, end int64) bool
 
 func newBaseCondition(fieldType consts.FieldType) FilterCondition {
 	return FilterCondition{
@@ -28,27 +28,27 @@ func newPackageCondition(fieldType consts.FieldType, targets []string) (FilterCo
 
 	switch fieldType {
 	case consts.FieldName:
-		filterFunc = func(pkg PackageInfo) bool {
+		filterFunc = func(pkg *PkgInfo) bool {
 			return pkgdata.FilterByStrings(pkg.Name, targets)
 		}
 	case consts.FieldArch:
-		filterFunc = func(pkg PackageInfo) bool {
+		filterFunc = func(pkg *PkgInfo) bool {
 			return pkgdata.FilterByStrings(pkg.Arch, targets)
 		}
 	case consts.FieldRequiredBy:
-		filterFunc = func(pkg PackageInfo) bool {
+		filterFunc = func(pkg *PkgInfo) bool {
 			return pkgdata.FilterByRelation(pkg.RequiredBy, targets)
 		}
 	case consts.FieldDepends:
-		filterFunc = func(pkg PackageInfo) bool {
+		filterFunc = func(pkg *PkgInfo) bool {
 			return pkgdata.FilterByRelation(pkg.Depends, targets)
 		}
 	case consts.FieldProvides:
-		filterFunc = func(pkg PackageInfo) bool {
+		filterFunc = func(pkg *PkgInfo) bool {
 			return pkgdata.FilterByRelation(pkg.Provides, targets)
 		}
 	case consts.FieldConflicts:
-		filterFunc = func(pkg PackageInfo) bool {
+		filterFunc = func(pkg *PkgInfo) bool {
 			return pkgdata.FilterByRelation(pkg.Conflicts, targets)
 		}
 	default:
@@ -69,14 +69,14 @@ func newRangeCondition(
 	condition := newBaseCondition(fieldType)
 
 	if rangeSelector.IsExact {
-		condition.Filter = func(pkg PackageInfo) bool {
+		condition.Filter = func(pkg *PkgInfo) bool {
 			return exactFunc(pkg, rangeSelector.Start)
 		}
 
 		return condition
 	}
 
-	condition.Filter = func(pkg PackageInfo) bool {
+	condition.Filter = func(pkg *PkgInfo) bool {
 		return rangeFunc(pkg, rangeSelector.Start, rangeSelector.End)
 	}
 
@@ -103,7 +103,7 @@ func newSizeCondition(sizeFilter RangeSelector) FilterCondition {
 
 func newReasonCondition(reason string) FilterCondition {
 	condition := newBaseCondition(consts.FieldReason)
-	condition.Filter = func(pkg PackageInfo) bool {
+	condition.Filter = func(pkg *PkgInfo) bool {
 		return pkgdata.FilterByReason(pkg.Reason, reason)
 	}
 

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -10,7 +10,7 @@ import (
 )
 
 type (
-	PackageInfo     = pkgdata.PkgInfo
+	PkgInfo         = pkgdata.PkgInfo
 	FilterCondition = pkgdata.FilterCondition
 )
 

--- a/internal/pkgdata/filters.go
+++ b/internal/pkgdata/filters.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-type Filter func(PkgInfo) bool
+type Filter func(*PkgInfo) bool
 
 type FilterCondition struct {
 	Filter    Filter
@@ -31,23 +31,23 @@ func FilterByReason(installReason string, targetReason string) bool {
 	return installReason == targetReason
 }
 
-func FilterExplicit(pkg PkgInfo) bool {
+func FilterExplicit(pkg *PkgInfo) bool {
 	return pkg.Reason == "explicit"
 }
 
-func FilterDependencies(pkg PkgInfo) bool {
+func FilterDependencies(pkg *PkgInfo) bool {
 	return pkg.Reason == "dependency"
 }
 
 // filters for packages installed on specific date
-func FilterByDate(pkg PkgInfo, date int64) bool {
+func FilterByDate(pkg *PkgInfo, date int64) bool {
 	pkgDate := time.Unix(pkg.Timestamp, 0)
 	targetDate := time.Unix(date, 0)
 	return pkgDate.Year() == targetDate.Year() && pkgDate.YearDay() == targetDate.YearDay()
 }
 
 // inclusive
-func FilterByDateRange(pkg PkgInfo, start int64, end int64) bool {
+func FilterByDateRange(pkg *PkgInfo, start int64, end int64) bool {
 	return !(pkg.Timestamp < start || pkg.Timestamp > end)
 }
 
@@ -63,11 +63,11 @@ func roundSizeInBytes(num int64) int64 {
 }
 
 // TODO: let's pre-round the inputs outside of these functions
-func FilterBySize(pkg PkgInfo, targetSize int64) bool {
+func FilterBySize(pkg *PkgInfo, targetSize int64) bool {
 	return roundSizeInBytes(pkg.Size) == roundSizeInBytes(targetSize)
 }
 
-func FilterBySizeRange(pkg PkgInfo, startSize int64, endSize int64) bool {
+func FilterBySizeRange(pkg *PkgInfo, startSize int64, endSize int64) bool {
 	roundedSize := roundSizeInBytes(pkg.Size)
 	return !(roundedSize < roundSizeInBytes(startSize) || roundedSize > roundSizeInBytes(endSize))
 }
@@ -84,45 +84,47 @@ func FilterByStrings(pkgString string, targetStrings []string) bool {
 
 func FilterPackages(
 	pkgs []PkgInfo,
-	filters []FilterCondition,
+	filterConditions []FilterCondition,
 	reportProgress ProgressReporter,
 ) []PkgInfo {
-	if len(filters) < 1 {
+	if len(filterConditions) < 1 {
 		return pkgs
 	}
 
-	inputChan := populateInitialInputChannel(pkgs)
-	outputChan := applyFilterPipeline(inputChan, filters, reportProgress)
+	pkgPtrs := convertToPointers(pkgs)
+
+	inputChan := populateInitialInputChannel(pkgPtrs)
+	outputChan := applyFilterPipeline(inputChan, filterConditions, reportProgress)
 	return collectFilteredResults(outputChan)
 }
 
-func collectFilteredResults(outputChan <-chan PkgInfo) []PkgInfo {
-	var filteredPackages []PkgInfo
+func collectFilteredResults(outputChan <-chan *PkgInfo) []PkgInfo {
+	var filteredPkgs []PkgInfo
 
 	for pkg := range outputChan {
-		filteredPackages = append(filteredPackages, pkg)
+		filteredPkgs = append(filteredPkgs, *pkg)
 	}
 
-	return filteredPackages
+	return filteredPkgs
 }
 
 func applyFilterPipeline(
-	inputChan <-chan PkgInfo,
-	filters []FilterCondition,
+	inputChan <-chan *PkgInfo,
+	filterConditions []FilterCondition,
 	reportProgress ProgressReporter,
-) <-chan PkgInfo {
+) <-chan *PkgInfo {
 	outputChan := inputChan
-	totalPhases := len(filters)
+	totalPhases := len(filterConditions)
 	completedPhases := 0
 	chunkSize := 100
 
-	for filterIndex, f := range filters {
-		nextOutputChan := make(chan PkgInfo, cap(inputChan))
+	for filterIndex, f := range filterConditions {
+		nextOutputChan := make(chan *PkgInfo, cap(inputChan))
 
-		go func(inChan <-chan PkgInfo, outChan chan<- PkgInfo, filter Filter, phaseName string) {
+		go func(inChan <-chan *PkgInfo, outChan chan<- *PkgInfo, filter Filter, phaseName string) {
 			defer close(outChan)
 
-			var chunk []PkgInfo
+			var chunk []*PkgInfo
 			for pkg := range inChan {
 				chunk = append(chunk, pkg)
 
@@ -152,19 +154,19 @@ func applyFilterPipeline(
 	return outputChan
 }
 
-func processChunk(pkgs []PkgInfo, outChan chan<- PkgInfo, filter Filter) {
-	for i := range pkgs {
-		if filter(pkgs[i]) {
-			outChan <- pkgs[i]
+func processChunk(pkgPtrs []*PkgInfo, outChan chan<- *PkgInfo, filter Filter) {
+	for i := range pkgPtrs {
+		if filter(pkgPtrs[i]) {
+			outChan <- pkgPtrs[i]
 		}
 	}
 }
 
-func populateInitialInputChannel(pkgs []PkgInfo) <-chan PkgInfo {
-	inputChan := make(chan PkgInfo, len(pkgs))
+func populateInitialInputChannel(pkgPtrs []*PkgInfo) <-chan *PkgInfo {
+	inputChan := make(chan *PkgInfo, len(pkgPtrs))
 
 	go func() {
-		for _, pkg := range pkgs {
+		for _, pkg := range pkgPtrs {
 			inputChan <- pkg
 		}
 

--- a/internal/pkgdata/filters.go
+++ b/internal/pkgdata/filters.go
@@ -116,10 +116,10 @@ func applyFilterPipeline(
 	outputChan := inputChan
 	totalPhases := len(filterConditions)
 	completedPhases := 0
-	chunkSize := 100
+	chunkSize := 20
 
 	for filterIndex, f := range filterConditions {
-		nextOutputChan := make(chan *PkgInfo, cap(inputChan))
+		nextOutputChan := make(chan *PkgInfo, chunkSize)
 
 		go func(inChan <-chan *PkgInfo, outChan chan<- *PkgInfo, filter Filter, phaseName string) {
 			defer close(outChan)

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -14,3 +14,21 @@ type PkgInfo struct {
 	License    string   `json:"license,omitempty"`
 	Url        string   `json:"url,omitempty"`
 }
+
+func convertToPointers(pkgs []PkgInfo) []*PkgInfo {
+	pkgPtrs := make([]*PkgInfo, len(pkgs))
+	for i := range pkgs {
+		pkgPtrs[i] = &pkgs[i]
+	}
+
+	return pkgPtrs
+}
+
+func dereferencePkgPointers(pkgPtrs []*PkgInfo) []PkgInfo {
+	pkgs := make([]PkgInfo, len(pkgPtrs))
+	for i := range pkgPtrs {
+		pkgs[i] = *pkgPtrs[i]
+	}
+
+	return pkgs
+}

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -195,25 +195,12 @@ func SortPackages(
 ) ([]PkgInfo, error) {
 	comparator := getComparator(cfg.SortBy)
 	phase := "Sorting packages"
-
-	pkgPointers := make([]*PkgInfo, len(pkgs))
-	for i := range pkgs {
-		pkgPointers[i] = &pkgs[i]
-	}
+	pkgPtrs := convertToPointers(pkgs)
 
 	// threshold is 500 as that is where merge sorting chunk performance overtakes timsort
 	if len(pkgs) < concurrentSortThreshold {
-		return sortNormally(pkgPointers, comparator, phase, reportProgress), nil
+		return sortNormally(pkgPtrs, comparator, phase, reportProgress), nil
 	}
 
-	return sortConcurrently(pkgPointers, comparator, phase, reportProgress), nil
-}
-
-func dereferencePkgPointers(pkgPointers []*PkgInfo) []PkgInfo {
-	pkgs := make([]PkgInfo, len(pkgPointers))
-	for i := range pkgPointers {
-		pkgs[i] = *pkgPointers[i]
-	}
-
-	return pkgs
+	return sortConcurrently(pkgPtrs, comparator, phase, reportProgress), nil
 }


### PR DESCRIPTION
Filters now run concurrently passing chunks of packages between each other. The packages are also now pointers instead of doing **pointless** copying. Chunk size has been adjusted to account for pipeline back pressure. 

Once all pipeline phases are using package pointers, we will no longer need to convert and deference packages to pointers at the beginning/end of each phase.   