### PR TITLE
Feature: Optimize filter order

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ because yay is my preferred AUR helper and the name has a good flow.
 - [x] package conflicts field
 - [x] conflicts filter
 - [ ] name exclusion filter
-- [ ] self-referencing column
+- [ ] self-referencing field
 - [x] JSON output
 - [x] no-headers option
 - [x] provides filter
@@ -94,11 +94,13 @@ because yay is my preferred AUR helper and the name has a good flow.
 - [x] config dependency injection for testing
 - [ ] required-by count sort
 - [x] metaflag for all filters
-- [x] license field
+- [x] package license field
 - [ ] XML output
+- [x] use chunked channel-based concurrent filtering (12% speed boost) 
 - [ ] short-args for filters
 - [ ] license sort
 - [x] architecture filter
+- [x] optimize filter ordering (4% speed boost)
 - [ ] dependency count sort
 - [ ] license filter
 - [ ] optional dependency field

--- a/internal/consts/fields.go
+++ b/internal/consts/fields.go
@@ -59,6 +59,7 @@ var FieldTypeLookup = map[string]FieldType{
 var FieldNameLookup = map[FieldType]string{
 	FieldDate:       date,
 	FieldName:       name,
+	FieldSize:       size,
 	FieldReason:     reason,
 	FieldVersion:    version,
 	FieldDepends:    depends,

--- a/internal/consts/fields.go
+++ b/internal/consts/fields.go
@@ -2,19 +2,20 @@ package consts
 
 type FieldType int
 
+// ordered by filter efficiency
 const (
-	FieldDate FieldType = iota
+	FieldReason FieldType = iota
+	FieldArch
+	FieldLicense
 	FieldName
-	FieldReason
+	FieldUrl
 	FieldSize
+	FieldDate
 	FieldVersion
 	FieldDepends
 	FieldRequiredBy
 	FieldProvides
 	FieldConflicts
-	FieldArch
-	FieldLicense
-	FieldUrl
 )
 
 const (

--- a/internal/consts/fields.go
+++ b/internal/consts/fields.go
@@ -1,6 +1,21 @@
 package consts
 
-type FieldType string
+type FieldType int
+
+const (
+	FieldDate FieldType = iota
+	FieldName
+	FieldReason
+	FieldSize
+	FieldVersion
+	FieldDepends
+	FieldRequiredBy
+	FieldProvides
+	FieldConflicts
+	FieldArch
+	FieldLicense
+	FieldUrl
+)
 
 const (
 	date       = "date"
@@ -15,21 +30,6 @@ const (
 	arch       = "arch"
 	license    = "license"
 	url        = "url"
-)
-
-const (
-	FieldDate       FieldType = date
-	FieldName       FieldType = name
-	FieldReason     FieldType = reason
-	FieldSize       FieldType = size
-	FieldVersion    FieldType = version
-	FieldDepends    FieldType = depends
-	FieldRequiredBy FieldType = requiredBy
-	FieldProvides   FieldType = provides
-	FieldConflicts  FieldType = conflicts
-	FieldArch       FieldType = arch
-	FieldLicense    FieldType = license
-	FieldUrl        FieldType = url
 )
 
 var FieldTypeLookup = map[string]FieldType{
@@ -54,6 +54,20 @@ var FieldTypeLookup = map[string]FieldType{
 	arch:       FieldArch,
 	license:    FieldLicense,
 	url:        FieldUrl,
+}
+
+var FieldNameLookup = map[FieldType]string{
+	FieldDate:       date,
+	FieldName:       name,
+	FieldReason:     reason,
+	FieldVersion:    version,
+	FieldDepends:    depends,
+	FieldRequiredBy: requiredBy,
+	FieldProvides:   provides,
+	FieldConflicts:  conflicts,
+	FieldArch:       arch,
+	FieldLicense:    license,
+	FieldUrl:        url,
 }
 
 var (

--- a/internal/pipeline/condition_filters.go
+++ b/internal/pipeline/condition_filters.go
@@ -18,7 +18,8 @@ type RangeFilter func(pkg *PkgInfo, start int64, end int64) bool
 
 func newBaseCondition(fieldType consts.FieldType) FilterCondition {
 	return FilterCondition{
-		PhaseName: "Filtering by " + string(fieldType),
+		PhaseName: "Filtering by " + consts.FieldNameLookup[fieldType],
+		FieldType: fieldType,
 	}
 }
 
@@ -52,7 +53,7 @@ func newPackageCondition(fieldType consts.FieldType, targets []string) (*FilterC
 			return pkgdata.FilterByRelation(pkg.Conflicts, targets)
 		}
 	default:
-		return nil, fmt.Errorf("invalid field for package filter: %s", fieldType)
+		return nil, fmt.Errorf("invalid field for package filter: %s", consts.FieldNameLookup[fieldType])
 	}
 
 	conditionFilter.Filter = filterFunc

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"yaylog/internal/config"
 	"yaylog/internal/consts"
@@ -18,9 +19,9 @@ var targetListRegex = regexp.MustCompile(`^([a-z0-9][a-z0-9._-]*[a-z0-9])(,([a-z
 
 func PreprocessFiltering(
 	cfg config.Config,
-	pkgPrts []*pkgdata.PkgInfo,
+	pkgPrts []*PkgInfo,
 	reportProgress pkgdata.ProgressReporter,
-) ([]*pkgdata.PkgInfo, error) {
+) ([]*PkgInfo, error) {
 	if len(cfg.FilterQueries) == 0 {
 		return pkgPrts, nil
 	}
@@ -34,13 +35,13 @@ func PreprocessFiltering(
 }
 
 func queriesToConditions(filterQueries map[consts.FieldType]string) (
-	[]*pkgdata.FilterCondition,
+	[]*FilterCondition,
 	error,
 ) {
-	conditions := make([]*pkgdata.FilterCondition, 0, len(filterQueries))
+	conditions := make([]*FilterCondition, 0, len(filterQueries))
 
 	for fieldType, value := range filterQueries {
-		var condition *pkgdata.FilterCondition
+		var condition *FilterCondition
 		var err error
 
 		switch fieldType {
@@ -58,15 +59,27 @@ func queriesToConditions(filterQueries map[consts.FieldType]string) (
 		case consts.FieldReason:
 			condition, err = parseReasonFilterCondition(value)
 		default:
-			err = fmt.Errorf("unsupported filter type: %s", fieldType)
+			err = fmt.Errorf("unsupported filter type: %s", consts.FieldNameLookup[fieldType])
 		}
 
 		if err != nil {
-			return []*pkgdata.FilterCondition{}, err
+			return []*FilterCondition{}, err
 		}
 
 		conditions = append(conditions, condition)
 	}
+
+	// sort filters in order of efficiency
+	sort.Slice(conditions, func(i int, j int) bool {
+		return conditions[i].FieldType < conditions[j].FieldType
+	})
+
+	derefedConditions := make([]FilterCondition, 0, len(conditions))
+	for _, cond := range conditions {
+		derefedConditions = append(derefedConditions, *(cond))
+	}
+
+	fmt.Println(derefedConditions)
 
 	return conditions, nil
 }

--- a/internal/pipeline/process.go
+++ b/internal/pipeline/process.go
@@ -74,13 +74,6 @@ func queriesToConditions(filterQueries map[consts.FieldType]string) (
 		return conditions[i].FieldType < conditions[j].FieldType
 	})
 
-	derefedConditions := make([]FilterCondition, 0, len(conditions))
-	for _, cond := range conditions {
-		derefedConditions = append(derefedConditions, *(cond))
-	}
-
-	fmt.Println(derefedConditions)
-
 	return conditions, nil
 }
 

--- a/internal/pkgdata/filters.go
+++ b/internal/pkgdata/filters.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"strings"
 	"time"
+	"yaylog/internal/consts"
 )
 
 type Filter func(*PkgInfo) bool
@@ -12,6 +13,7 @@ type Filter func(*PkgInfo) bool
 type FilterCondition struct {
 	Filter    Filter
 	PhaseName string
+	FieldType consts.FieldType
 }
 
 func FilterByRelation(pkgNames []string, targetNames []string) bool {

--- a/internal/pkgdata/reverse_dependencies.go
+++ b/internal/pkgdata/reverse_dependencies.go
@@ -17,8 +17,9 @@ func CalculateReverseDependencies(
 	_ ProgressReporter, // TODO: Add progress reporting
 ) ([]*PkgInfo, error) {
 	_, hasRequiredByFilter := cfg.FilterQueries[consts.FieldRequiredBy]
+	hasRequiredByField := slices.Contains(cfg.Fields, consts.FieldRequiredBy)
 
-	if !slices.Contains(cfg.Fields, consts.FieldRequiredBy) && !hasRequiredByFilter {
+	if !hasRequiredByField && !hasRequiredByFilter {
 		return pkgPtrs, nil
 	}
 


### PR DESCRIPTION
Filters are now ordered by categorical/primitive filters, range filters, then graph filters. Instead of using string names as the FieldType value, we now use iotas as a form of enum. This both enables us to not only stop passing around strings everywhere, but we can also use the order of the integer values of the FieldTypes to give them precedence. They are also ordered by the likelihood of the field being populated.

This is now the order of filtering:
```
FieldReason
FieldArch
FieldLicense
FieldName
FieldUrl
FieldSize
FieldDate
FieldVersion
FieldDepends
FieldRequiredBy
FieldProvides
FieldConflicts
```

Addresses #126 