### PR TITLE
Feature: Use unstable sort

### DIFF
--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -85,7 +85,7 @@ func sortConcurrently(
 
 	numCPUs := runtime.NumCPU()
 	baseChunkSize := total / (2 * numCPUs)
-	chunkSize := min(100, baseChunkSize)
+	chunkSize := max(100, baseChunkSize)
 
 	var mu sync.Mutex
 	var wg sync.WaitGroup

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -85,7 +85,7 @@ func sortConcurrently(
 
 	numCPUs := runtime.NumCPU()
 	baseChunkSize := total / (2 * numCPUs)
-	chunkSize := max(100, baseChunkSize)
+	chunkSize := min(100, baseChunkSize)
 
 	var mu sync.Mutex
 	var wg sync.WaitGroup

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -87,30 +87,21 @@ func sortConcurrently(
 	baseChunkSize := total / (2 * numCPUs)
 	chunkSize := max(100, baseChunkSize)
 
-	var mu sync.Mutex
 	var wg sync.WaitGroup
-
 	numChunks := (total + chunkSize - 1) / chunkSize
-	chunks := make([][]*PkgInfo, 0, numChunks) // pre-allocate
 
 	for chunkIdx := range numChunks {
 		startIdx := chunkIdx * chunkSize
 		endIdx := min(startIdx+chunkSize, total)
 
-		chunk := pkgPtrs[startIdx:endIdx]
-
 		wg.Add(1)
 
-		go func(c []*PkgInfo) {
+		go func() {
 			defer wg.Done()
 
-			sort.SliceStable(c, func(i int, j int) bool {
-				return comparator(c[i], c[j])
+			sort.SliceStable(pkgPtrs[startIdx:endIdx], func(i int, j int) bool {
+				return comparator(pkgPtrs[i], pkgPtrs[j])
 			})
-
-			mu.Lock()
-			chunks = append(chunks, c)
-			mu.Unlock()
 
 			if reportProgress != nil {
 				currentProgress := (chunkIdx + 1) * 50 / numChunks // scale chunk sorting progress to 0%-50%
@@ -120,7 +111,7 @@ func sortConcurrently(
 					fmt.Sprintf("%s - Sorted chunk %d/%d", phase, chunkIdx+1, numChunks),
 				)
 			}
-		}(chunk)
+		}()
 	}
 
 	wg.Wait()
@@ -130,40 +121,15 @@ func sortConcurrently(
 		reportProgress(50, 100, fmt.Sprintf("%s - Initial chunk sorting complete", phase))
 	}
 
-	mergeStep := 0
-
-	for len(chunks) > 1 {
-		var newChunks [][]*PkgInfo
-
-		for i := 0; i < len(chunks); i += 2 {
-			if i+1 < len(chunks) {
-				mergedChunk := mergedSortedChunks(chunks[i], chunks[i+1], comparator)
-				newChunks = append(newChunks, mergedChunk)
-
-				continue
-			}
-
-			newChunks = append(newChunks, chunks[i]) // move odd chunk forward
-		}
-
-		chunks = newChunks
-
-		if reportProgress != nil {
-			mergeStep++
-			currentProgress := 50 + (mergeStep * 50 / (numChunks - 1)) // scale to 50%-100%
-			reportProgress(currentProgress, 100, fmt.Sprintf("%s - Merging step %d", phase, mergeStep))
-		}
-	}
+	sort.SliceStable(pkgPtrs, func(i int, j int) bool {
+		return comparator(pkgPtrs[i], pkgPtrs[j])
+	})
 
 	if reportProgress != nil {
 		reportProgress(total, total, fmt.Sprintf("%s completed", phase))
 	}
 
-	if len(chunks) == 1 {
-		return chunks[0]
-	}
-
-	return nil
+	return pkgPtrs
 }
 
 // pkgPointers will be sorted in place, mutating the slice order

--- a/internal/pkgdata/sort.go
+++ b/internal/pkgdata/sort.go
@@ -99,7 +99,7 @@ func sortConcurrently(
 		go func() {
 			defer wg.Done()
 
-			sort.SliceStable(pkgPtrs[startIdx:endIdx], func(i int, j int) bool {
+			sort.Slice(pkgPtrs[startIdx:endIdx], func(i int, j int) bool {
 				return comparator(pkgPtrs[i], pkgPtrs[j])
 			})
 
@@ -121,7 +121,7 @@ func sortConcurrently(
 		reportProgress(50, 100, fmt.Sprintf("%s - Initial chunk sorting complete", phase))
 	}
 
-	sort.SliceStable(pkgPtrs, func(i int, j int) bool {
+	sort.Slice(pkgPtrs, func(i int, j int) bool {
 		return comparator(pkgPtrs[i], pkgPtrs[j])
 	})
 
@@ -143,7 +143,7 @@ func sortNormally(
 		reportProgress(0, 100, fmt.Sprintf("%s - normally", phase))
 	}
 
-	sort.SliceStable(pkgPtrs, func(i int, j int) bool {
+	sort.Slice(pkgPtrs, func(i int, j int) bool {
 		return comparator(pkgPtrs[i], pkgPtrs[j])
 	})
 


### PR DESCRIPTION
We don't have a good reason to be using `sort.SliceStable` over `sort.Slice` in the middle of chunked merge sort or in normal sort. 