### PR TITLE
Feature: Add description field

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ this package is compatible with the following distributions:
 
 ## features
 
-- list installed packages with date/timestamps, dependencies, provisions, requirements, size on disk, conflicts, architecture, and version
+- list installed packages with date/timestamps, dependencies, provisions, requirements, size on disk, conflicts, architecture, description, and version
 - filter by explicitly installed packages
 - filter by packages installed as dependencies
 - filter by packages required by specified packages
@@ -79,7 +79,7 @@ because yay is my preferred AUR helper and the name has a good flow.
 - [x] user defined columns
 - [x] dependencies of each package (dependency field)
 - [x] reverse-dependencies of each package (required-by field)
-- [ ] package description field
+- [x] package description field
 - [x] package URL field
 - [x] package architecture field
 - [x] package conflicts field
@@ -214,6 +214,7 @@ short-flag filters and long-flag filters can be combined.
 - `arch` - architecture the package was built for (e.g., x86_64, aarch64, any)
 - `license` - package software license
 - `url` - the URL of the official site of the software being packaged
+- `description` - package description
 
 ### JSON output
 the `--json` flag outputs the package data as structured JSON instead of a table. this can be useful for scripts or automation.
@@ -230,10 +231,14 @@ output format:
 [
   {
     "timestamp": 1739294218,
+    "size": 4385422,
     "name": "tinysparql",
     "reason": "dependency",
-    "size": 4385422,
     "version": "3.8.2-2",
+    "arch": "aarch64",
+    "license": "GPL-2.0-or-later",
+    "url": "https://tinysparql.org/",
+    "description": "Low-footprint RDF triple store with SPARQL 1.1 interface",
     "depends": [
       "avahi",
       "gcc-libs",
@@ -246,20 +251,13 @@ output format:
       "libxml2",
       "sqlite"
     ],
-    "requiredBy": [
-      "gtk3",
-      "gtk4"
-    ],
     "provides": [
       "tracker3=3.8.2",
       "libtinysparql-3.0.so=0-64"
     ],
     "conflicts": [
       "tracker3<=3.7.3-2"
-    ],
-    "arch": "aarch64",
-    "license": "GPL-2.0-or-later",
-    "url": "https://tinysparql.org/"
+    ]
   }
 ]
 ```
@@ -368,9 +366,9 @@ are treated as separate parameters.
    ```bash
    yaylog --columns name,version,size
    ```
-16. show package names and dependencies with `less` for readability
+16. show package names, descriptions, and dependencies with `less` for readability
    ```bash
-   yaylog --columns name,depends | less
+   yaylog --columns name,depends,description | less
    ```
 17. output package data in JSON format
    ```bash

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ because yay is my preferred AUR helper and the name has a good flow.
 - [x] use chunked channel-based concurrent filtering (12% speed boost) 
 - [ ] short-args for filters
 - [ ] license sort
+- [ ] packager field
 - [ ] streaming pipeline
 - [x] architecture filter
 - [x] optimize filter ordering (4% speed boost)
@@ -110,6 +111,8 @@ because yay is my preferred AUR helper and the name has a good flow.
 - [ ] license filter
 - [ ] optional dependency field
 - [x] improve sorting efficiency (8% speed boost)
+- [ ] package base field
+- [ ] package description filter
 
 ## installation
 

--- a/internal/consts/fields.go
+++ b/internal/consts/fields.go
@@ -8,6 +8,7 @@ const (
 	FieldArch
 	FieldLicense
 	FieldName
+	FieldDescription
 	FieldUrl
 	FieldSize
 	FieldDate
@@ -19,18 +20,19 @@ const (
 )
 
 const (
-	date       = "date"
-	name       = "name"
-	reason     = "reason"
-	size       = "size"
-	version    = "version"
-	depends    = "depends"
-	requiredBy = "required-by"
-	provides   = "provides"
-	conflicts  = "conflicts"
-	arch       = "arch"
-	license    = "license"
-	url        = "url"
+	date        = "date"
+	name        = "name"
+	reason      = "reason"
+	size        = "size"
+	version     = "version"
+	description = "description"
+	depends     = "depends"
+	requiredBy  = "required-by"
+	provides    = "provides"
+	conflicts   = "conflicts"
+	arch        = "arch"
+	license     = "license"
+	url         = "url"
 )
 
 var FieldTypeLookup = map[string]FieldType{
@@ -43,18 +45,19 @@ var FieldTypeLookup = map[string]FieldType{
 	"R": FieldRequiredBy,
 	"p": FieldProvides,
 
-	date:       FieldDate,
-	name:       FieldName,
-	reason:     FieldReason,
-	size:       FieldSize,
-	version:    FieldVersion,
-	depends:    FieldDepends,
-	requiredBy: FieldRequiredBy,
-	provides:   FieldProvides,
-	conflicts:  FieldConflicts,
-	arch:       FieldArch,
-	license:    FieldLicense,
-	url:        FieldUrl,
+	date:        FieldDate,
+	name:        FieldName,
+	reason:      FieldReason,
+	arch:        FieldArch,
+	license:     FieldLicense,
+	url:         FieldUrl,
+	description: FieldDescription,
+	size:        FieldSize,
+	version:     FieldVersion,
+	depends:     FieldDepends,
+	requiredBy:  FieldRequiredBy,
+	provides:    FieldProvides,
+	conflicts:   FieldConflicts,
 }
 
 var FieldNameLookup = map[FieldType]string{
@@ -92,5 +95,6 @@ var (
 		FieldArch,
 		FieldLicense,
 		FieldUrl,
+		FieldDescription,
 	}
 )

--- a/internal/display/render_json.go
+++ b/internal/display/render_json.go
@@ -9,18 +9,19 @@ import (
 )
 
 type PkgInfoJson struct {
-	Timestamp  int64    `json:"timestamp,omitempty"`
-	Size       int64    `json:"size,omitempty"`
-	Name       string   `json:"name,omitempty"`
-	Reason     string   `json:"reason,omitempty"`
-	Version    string   `json:"version,omitempty"`
-	Arch       string   `json:"arch,omitempty"`
-	License    string   `json:"license,omitempty"`
-	Url        string   `json:"url,omitempty"`
-	Depends    []string `json:"depends,omitempty"`
-	RequiredBy []string `json:"requiredBy,omitempty"`
-	Provides   []string `json:"provides,omitempty"`
-	Conflicts  []string `json:"conflicts,omitempty"`
+	Timestamp   int64    `json:"timestamp,omitempty"`
+	Size        int64    `json:"size,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Reason      string   `json:"reason,omitempty"`
+	Version     string   `json:"version,omitempty"`
+	Arch        string   `json:"arch,omitempty"`
+	License     string   `json:"license,omitempty"`
+	Url         string   `json:"url,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Depends     []string `json:"depends,omitempty"`
+	RequiredBy  []string `json:"requiredBy,omitempty"`
+	Provides    []string `json:"provides,omitempty"`
+	Conflicts   []string `json:"conflicts,omitempty"`
 }
 
 func (o *OutputManager) renderJson(pkgPtrs []*pkgdata.PkgInfo, fields []consts.FieldType) {
@@ -80,6 +81,14 @@ func getJsonValues(pkg *pkgdata.PkgInfo, fields []consts.FieldType) *PkgInfoJson
 			filteredPackage.Size = pkg.Size // return in bytes for json
 		case consts.FieldVersion:
 			filteredPackage.Version = pkg.Version
+		case consts.FieldArch:
+			filteredPackage.Arch = pkg.Arch
+		case consts.FieldLicense:
+			filteredPackage.License = pkg.License
+		case consts.FieldUrl:
+			filteredPackage.Url = pkg.Url
+		case consts.FieldDescription:
+			filteredPackage.Description = pkg.Description
 		case consts.FieldDepends:
 			filteredPackage.Depends = flattenRelations(pkg.Depends)
 		case consts.FieldRequiredBy:
@@ -88,12 +97,6 @@ func getJsonValues(pkg *pkgdata.PkgInfo, fields []consts.FieldType) *PkgInfoJson
 			filteredPackage.Provides = flattenRelations(pkg.Provides)
 		case consts.FieldConflicts:
 			filteredPackage.Conflicts = flattenRelations(pkg.Conflicts)
-		case consts.FieldArch:
-			filteredPackage.Arch = pkg.Arch
-		case consts.FieldLicense:
-			filteredPackage.License = pkg.License
-		case consts.FieldUrl:
-			filteredPackage.Url = pkg.Url
 		}
 	}
 

--- a/internal/display/render_table.go
+++ b/internal/display/render_table.go
@@ -15,18 +15,19 @@ type tableContext struct {
 }
 
 var columnHeaders = map[consts.FieldType]string{
-	consts.FieldDate:       "DATE",
-	consts.FieldName:       "NAME",
-	consts.FieldReason:     "REASON",
-	consts.FieldSize:       "SIZE",
-	consts.FieldVersion:    "VERSION",
-	consts.FieldDepends:    "DEPENDS",
-	consts.FieldRequiredBy: "REQUIRED BY",
-	consts.FieldProvides:   "PROVIDES",
-	consts.FieldConflicts:  "CONFLICTS",
-	consts.FieldArch:       "ARCH",
-	consts.FieldLicense:    "LICENSE",
-	consts.FieldUrl:        "URL",
+	consts.FieldDate:        "DATE",
+	consts.FieldName:        "NAME",
+	consts.FieldReason:      "REASON",
+	consts.FieldSize:        "SIZE",
+	consts.FieldVersion:     "VERSION",
+	consts.FieldDepends:     "DEPENDS",
+	consts.FieldRequiredBy:  "REQUIRED BY",
+	consts.FieldProvides:    "PROVIDES",
+	consts.FieldConflicts:   "CONFLICTS",
+	consts.FieldArch:        "ARCH",
+	consts.FieldLicense:     "LICENSE",
+	consts.FieldUrl:         "URL",
+	consts.FieldDescription: "DESCRIPTION",
 }
 
 // displays data in tab format
@@ -109,6 +110,8 @@ func getTableValue(pkg *pkgdata.PkgInfo, field consts.FieldType, ctx tableContex
 		return pkg.License
 	case consts.FieldUrl:
 		return pkg.Url
+	case consts.FieldDescription:
+		return pkg.Description
 	default:
 		return ""
 	}

--- a/internal/pkgdata/cache.go
+++ b/internal/pkgdata/cache.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	cachePath    = "/tmp/yaylog.cache"
-	cacheVersion = 1
+	cacheVersion = 2 // bump when updating structure of PkgInfo/Relation/pkginfo.proto
 )
 
 func getDbModTime() (int64, error) {
@@ -89,18 +89,19 @@ func pkgsToProtos(pkgs []*PkgInfo) []*pb.PkgInfo {
 	pbPkgs := make([]*pb.PkgInfo, len(pkgs))
 	for i, pkg := range pkgs {
 		pbPkgs[i] = &pb.PkgInfo{
-			Timestamp:  pkg.Timestamp,
-			Size:       pkg.Size,
-			Name:       pkg.Name,
-			Reason:     pkg.Reason,
-			Version:    pkg.Version,
-			Arch:       pkg.Arch,
-			License:    pkg.License,
-			Url:        pkg.Url,
-			Depends:    relationsToProtos(pkg.Depends),
-			RequiredBy: relationsToProtos(pkg.RequiredBy),
-			Provides:   relationsToProtos(pkg.Provides),
-			Conflicts:  relationsToProtos(pkg.Conflicts),
+			Timestamp:   pkg.Timestamp,
+			Size:        pkg.Size,
+			Name:        pkg.Name,
+			Reason:      pkg.Reason,
+			Version:     pkg.Version,
+			Arch:        pkg.Arch,
+			License:     pkg.License,
+			Url:         pkg.Url,
+			Description: pkg.Description,
+			Depends:     relationsToProtos(pkg.Depends),
+			RequiredBy:  relationsToProtos(pkg.RequiredBy),
+			Provides:    relationsToProtos(pkg.Provides),
+			Conflicts:   relationsToProtos(pkg.Conflicts),
 		}
 	}
 
@@ -124,18 +125,19 @@ func protosToPkgs(pbPkgs []*pb.PkgInfo) []*PkgInfo {
 	pkgs := make([]*PkgInfo, len(pbPkgs))
 	for i, pbPkg := range pbPkgs {
 		pkgs[i] = &PkgInfo{
-			Timestamp:  pbPkg.Timestamp,
-			Size:       pbPkg.Size,
-			Name:       pbPkg.Name,
-			Reason:     pbPkg.Reason,
-			Version:    pbPkg.Version,
-			Arch:       pbPkg.Arch,
-			License:    pbPkg.License,
-			Url:        pbPkg.Url,
-			Depends:    protosToRelations(pbPkg.Depends),
-			RequiredBy: protosToRelations(pbPkg.RequiredBy),
-			Provides:   protosToRelations(pbPkg.Provides),
-			Conflicts:  protosToRelations(pbPkg.Conflicts),
+			Timestamp:   pbPkg.Timestamp,
+			Size:        pbPkg.Size,
+			Name:        pbPkg.Name,
+			Reason:      pbPkg.Reason,
+			Version:     pbPkg.Version,
+			Arch:        pbPkg.Arch,
+			License:     pbPkg.License,
+			Url:         pbPkg.Url,
+			Description: pbPkg.Description,
+			Depends:     protosToRelations(pbPkg.Depends),
+			RequiredBy:  protosToRelations(pbPkg.RequiredBy),
+			Provides:    protosToRelations(pbPkg.Provides),
+			Conflicts:   protosToRelations(pbPkg.Conflicts),
 		}
 	}
 

--- a/internal/pkgdata/fetch.go
+++ b/internal/pkgdata/fetch.go
@@ -24,6 +24,7 @@ const (
 	fieldArch        = "%ARCH%"
 	fieldLicense     = "%LICENSE%"
 	fieldUrl         = "%URL%"
+	fieldDescription = "%DESC%"
 
 	PacmanDbPath = "/var/lib/pacman/local"
 )
@@ -134,7 +135,7 @@ func parseDescFile(descPath string) (*PkgInfo, error) {
 
 			switch line {
 			case fieldName, fieldInstallDate, fieldSize, fieldReason,
-				fieldVersion, fieldArch, fieldLicense, fieldUrl:
+				fieldVersion, fieldArch, fieldLicense, fieldUrl, fieldDescription:
 				currentField = line
 
 			case fieldDepends, fieldProvides, fieldConflicts:
@@ -236,6 +237,9 @@ func applySingleLineField(pkg *PkgInfo, field string, value string) error {
 
 	case fieldUrl:
 		pkg.Url = value
+
+	case fieldDescription:
+		pkg.Description = value
 
 	default:
 		// ignore unknown fields

--- a/internal/pkgdata/packageinfo.go
+++ b/internal/pkgdata/packageinfo.go
@@ -18,16 +18,17 @@ type Relation struct {
 }
 
 type PkgInfo struct {
-	Timestamp  int64
-	Size       int64
-	Name       string
-	Reason     string
-	Version    string
-	Arch       string
-	License    string
-	Url        string
-	Depends    []Relation
-	RequiredBy []Relation
-	Provides   []Relation
-	Conflicts  []Relation
+	Timestamp   int64
+	Size        int64
+	Name        string
+	Reason      string
+	Version     string
+	Arch        string
+	License     string
+	Url         string
+	Description string
+	Depends     []Relation
+	RequiredBy  []Relation
+	Provides    []Relation
+	Conflicts   []Relation
 }

--- a/internal/protobuf/pkginfo.pb.go
+++ b/internal/protobuf/pkginfo.pb.go
@@ -9,12 +9,11 @@
 package protobuf
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -152,6 +151,7 @@ type PkgInfo struct {
 	Arch          string                 `protobuf:"bytes,6,opt,name=arch,proto3" json:"arch,omitempty"`
 	License       string                 `protobuf:"bytes,7,opt,name=license,proto3" json:"license,omitempty"`
 	Url           string                 `protobuf:"bytes,8,opt,name=url,proto3" json:"url,omitempty"`
+	Description   string                 `protobuf:"bytes,13,opt,name=description,proto3" json:"description,omitempty"`
 	Depends       []*Relation            `protobuf:"bytes,9,rep,name=depends,proto3" json:"depends,omitempty"`
 	RequiredBy    []*Relation            `protobuf:"bytes,10,rep,name=required_by,json=requiredBy,proto3" json:"required_by,omitempty"`
 	Provides      []*Relation            `protobuf:"bytes,11,rep,name=provides,proto3" json:"provides,omitempty"`
@@ -242,6 +242,13 @@ func (x *PkgInfo) GetLicense() string {
 func (x *PkgInfo) GetUrl() string {
 	if x != nil {
 		return x.Url
+	}
+	return ""
+}
+
+func (x *PkgInfo) GetDescription() string {
+	if x != nil {
+		return x.Description
 	}
 	return ""
 }
@@ -342,7 +349,7 @@ const file_protobuf_pkginfo_proto_rawDesc = "" +
 	"\bRelation\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n" +
 	"\aversion\x18\x02 \x01(\tR\aversion\x12/\n" +
-	"\boperator\x18\x03 \x01(\x0e2\x13.pkginfo.RelationOpR\boperator\"\x82\x03\n" +
+	"\boperator\x18\x03 \x01(\x0e2\x13.pkginfo.RelationOpR\boperator\"\xa4\x03\n" +
 	"\aPkgInfo\x12\x1c\n" +
 	"\ttimestamp\x18\x01 \x01(\x03R\ttimestamp\x12\x12\n" +
 	"\x04size\x18\x02 \x01(\x03R\x04size\x12\x12\n" +
@@ -351,7 +358,8 @@ const file_protobuf_pkginfo_proto_rawDesc = "" +
 	"\aversion\x18\x05 \x01(\tR\aversion\x12\x12\n" +
 	"\x04arch\x18\x06 \x01(\tR\x04arch\x12\x18\n" +
 	"\alicense\x18\a \x01(\tR\alicense\x12\x10\n" +
-	"\x03url\x18\b \x01(\tR\x03url\x12+\n" +
+	"\x03url\x18\b \x01(\tR\x03url\x12 \n" +
+	"\vdescription\x18\r \x01(\tR\vdescription\x12+\n" +
 	"\adepends\x18\t \x03(\v2\x11.pkginfo.RelationR\adepends\x122\n" +
 	"\vrequired_by\x18\n" +
 	" \x03(\v2\x11.pkginfo.RelationR\n" +
@@ -385,16 +393,14 @@ func file_protobuf_pkginfo_proto_rawDescGZIP() []byte {
 	return file_protobuf_pkginfo_proto_rawDescData
 }
 
-var (
-	file_protobuf_pkginfo_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-	file_protobuf_pkginfo_proto_msgTypes  = make([]protoimpl.MessageInfo, 3)
-	file_protobuf_pkginfo_proto_goTypes   = []any{
-		(RelationOp)(0),    // 0: pkginfo.RelationOp
-		(*Relation)(nil),   // 1: pkginfo.Relation
-		(*PkgInfo)(nil),    // 2: pkginfo.PkgInfo
-		(*CachedPkgs)(nil), // 3: pkginfo.CachedPkgs
-	}
-)
+var file_protobuf_pkginfo_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_protobuf_pkginfo_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_protobuf_pkginfo_proto_goTypes = []any{
+	(RelationOp)(0),    // 0: pkginfo.RelationOp
+	(*Relation)(nil),   // 1: pkginfo.Relation
+	(*PkgInfo)(nil),    // 2: pkginfo.PkgInfo
+	(*CachedPkgs)(nil), // 3: pkginfo.CachedPkgs
+}
 var file_protobuf_pkginfo_proto_depIdxs = []int32{
 	0, // 0: pkginfo.Relation.operator:type_name -> pkginfo.RelationOp
 	1, // 1: pkginfo.PkgInfo.depends:type_name -> pkginfo.Relation

--- a/protobuf/pkginfo.proto
+++ b/protobuf/pkginfo.proto
@@ -30,6 +30,7 @@ message PkgInfo {
   string arch = 6;
   string license = 7;
   string url = 8;
+  string description = 13;
 
   repeated Relation depends = 9;
   repeated Relation required_by = 10;

--- a/yaylog.1
+++ b/yaylog.1
@@ -158,6 +158,9 @@ Specify a comma-separated list of columns to display. Available columns:
 .IP
 .B url
 : URL of the official site of the software being packaged.
+.IP
+.B description
+: Package description.
 .TP
 .B \-\-all-columns
 Show all available columns.


### PR DESCRIPTION
Users can now list the package description with `yaylog --add-columns description` or `yaylog --columns description` or `yaylog --all-columns`.

Addresses #125 