### PR TITLE
Feature: Add license sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,11 @@ yaylog [options]
   - `--where depends=glibc`    -> query by packages that depend on `glibc`
   - `--where conflicts=sdl2`   -> query by packages that conflict with `sdl2`
   - `--where arch=x86_64`      -> query by packages that are built for `x86_64` CPUs
-- `-O` | `--order <mode>:<direction>`: sort results ascending or descending (default sort is `date:asc`):
+- `-O` | `--order <field>:<direction>`: sort results ascending or descending (default sort is `date:asc`):
   - `date`    -> sort by installation date
   - `name`    -> sort alphabetically by package name
-  - `size`    -> sort by package size
-  - `license` -> sort alphabetically by license
+  - `size`    -> sort by package size on disk
+  - `license` -> sort alphabetically by package license
 - `--no-headers`: omit column headers in table output (useful for scripting)
 - `-s` | `--select <list>`: comma-separated list of fields to display (cannot use with `--select-all` or `--select-add`)
 - `-S` | `--select-add <list>`: comma-separated list of fields to add to defaults or `--select-all`
@@ -213,7 +213,7 @@ short-flag queries and long-flag queries can be combined.
 - `depends` - list of dependencies (output can be long)
 - `required-by` - list of packages required by the package and are dependent (output can be long) 
 - `provides` - list of alternative package names or shared libraries provided by package (output can be long)
-- `conficts` - list of packages that conflict, or cause problems, with the package
+- `conflicts` - list of packages that conflict, or cause problems, with the package
 - `arch` - architecture the package was built for (e.g., x86_64, aarch64, any)
 - `license` - package software license
 - `url` - the URL of the official site of the software being packaged

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ because yay is my preferred AUR helper and the name has a good flow.
 ## installation
 
 ### from AUR (**recommended**)
-install using [AUR helper](https://wiki.archlinux.org/title/AUR_helpers) like `yay`:
+install using [AUR helper](https://wiki.archlinux.org/title/AUR_helpers) like `yay`, `paru`, `aura`, etc.:
 ```bash
-yay -S yaylog
+yay -Sy yaylog
 ```
 
 if you prefer to install a pre-compiled binary* using the AUR, use the `yaylog-bin` package instead.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ this package is compatible with the following distributions:
 - query by packages built with specified architectures
 - query by package size or size range
 - query by package name (substring match)
-- sort by installation date, alphabetically, or by size on disk
+- sort by installation date, package name, license, or by size on disk
 - output as a table or JSON
 
 ## why is it called yaylog if it works with other AUR helpers?
@@ -102,7 +102,7 @@ because yay is my preferred AUR helper and the name has a good flow.
 - [ ] XML output
 - [x] use chunked channel-based concurrent querying (12% speed boost) 
 - [ ] short-args for queries
-- [ ] license sort
+- [x] license sort
 - [ ] packager field
 - [ ] streaming pipeline
 - [x] architecture query
@@ -170,10 +170,11 @@ yaylog [options]
   - `--where depends=glibc`    -> query by packages that depend on `glibc`
   - `--where conflicts=sdl2`   -> query by packages that conflict with `sdl2`
   - `--where arch=x86_64`      -> query by packages that are built for `x86_64` CPUs
-- `-O` | `--order <mode>`: sort results by:
-  - `date` (default) - sort by installation date
-  - `alphabetical` - sort alphabetically by package name
-  - `size:asc` / `size:desc` - sort by package size (ascending or descending)
+- `-O` | `--order <mode>:<direction>`: sort results ascending or descending (default sort is `date:asc`):
+  - `date`    -> sort by installation date
+  - `name`    -> sort alphabetically by package name
+  - `size`    -> sort by package size
+  - `license` -> sort alphabetically by license
 - `--no-headers`: omit column headers in table output (useful for scripting)
 - `-s` | `--select <list>`: comma-separated list of fields to display (cannot use with `--select-all` or `--select-add`)
 - `-S` | `--select-add <list>`: comma-separated list of fields to add to defaults or `--select-all`
@@ -318,11 +319,11 @@ are treated as separate parameters.
    ```
  3. show only dependencies installed on a specific date
    ```bash
-   yaylog -w reason=dependencies -w date=2025-03-01
+   yaylog -w reason=dependency -w date=2025-03-01
    ```
- 4. show all packages sorted alphabetically
+ 4. show all packages sorted alphabetically by name
    ```bash
-   yaylog -a -O alphabetical
+   yaylog -a -O name
    ```
  5. show the 15 most recent explicitly installed packages
    ```bash
@@ -332,17 +333,17 @@ are treated as separate parameters.
    ```bash
    yaylog -w date=2024-07-01:2024-12-31
    ```
- 7. show the 20 most recently installed packages larger than 20MB
+ 7. sort all packages by their license, displaying name and license
+   ```
+   yaylog -aO license -s name,license
+   ```
+ 8. show the 20 most recently installed packages larger than 20MB
    ```bash
    yaylog -w size=20MB: -l 20
    ```
- 8. show all dependencies smaller than 500KB  
+ 9. show packages between 100MB and 1GB installed up to february 27, 2025
    ```bash
-   yaylog -w reason=dependencies -w size=:500KB
-   ```
- 9. show packages between 100MB and 1GB installed up to june 30, 2024
-   ```bash
-   yaylog -w size=100MB:1GB -w date=:2024-06-30
+   yaylog -w size=100MB:1GB -w date=:2025-02-27
    ```
 10. show all packages sorted by size in descending order, installed after january 1, 2025
    ```bash
@@ -356,9 +357,9 @@ are treated as separate parameters.
    ```bash
    yaylog -w reason=explicit -w name=lib -w size=10MB:1GB
    ```
-13. search for packages with names containing "linux" installed between january 1 and june 30, 2024
+13. search for packages with names containing "linux" installed between january 1 and march 30, 2025
    ```bash
-   yaylog -w name=linux -w date=2024-01-01:2024-06-30
+   yaylog -w name=linux -w date=2025-01-01:2025-03-30
    ```
 14. search for packages containing "gtk" installed after january 1, 2025, and at least 5MB in size
    ```bash
@@ -408,9 +409,9 @@ are treated as separate parameters.
    ```bash
    yaylog -a -w required-by=gtk3 -w size=50MB:
    ```
-26. show packages required by `vlc` and installed after january 1, 2024 
+26. show packages required by `vlc` and installed after january 1, 2025 
    ```bash
-   yaylog -w required-by=vlc -w date=2024-01-01:
+   yaylog -w required-by=vlc -w date=2025-01-01:
    ```
 27. show all packages that have `glibc` as a dependency and are required by `ffmpeg`
    ```bash
@@ -435,4 +436,8 @@ are treated as separate parameters.
 32. show packages that are built for the `aarch64` CPU architecture or any architecture (non-CPU-specific):
    ```bash
    yaylog -w arch=aarch64,any
+   ```
+33. show all dependencies smaller than 500KB  
+   ```bash
+   yaylog -w reason=dependencies -w size=:500KB
    ```

--- a/cmd/yaylog/main.go
+++ b/cmd/yaylog/main.go
@@ -9,13 +9,15 @@ import (
 	phasekit "yaylog/internal/pipeline/phase"
 	"yaylog/internal/pkgdata"
 
+	"github.com/spf13/pflag"
 	"golang.org/x/term"
 )
 
 func main() {
 	err := mainWithConfig(&config.CliConfigProvider{})
 	if err != nil {
-		out.WriteLine(err.Error())
+		out.WriteLine(err.Error() + "\n")
+		pflag.PrintDefaults()
 		os.Exit(1)
 	}
 }

--- a/cmd/yaylog/main_test.go
+++ b/cmd/yaylog/main_test.go
@@ -21,7 +21,7 @@ func (m *MockConfigProvider) GetConfig() (config.Config, error) {
 func TestMainWithConfig(t *testing.T) {
 	mockCfg := config.Config{
 		Count:      5,
-		SortBy:     "size:desc",
+		SortOption: config.SortOption{Field: consts.FieldSize, Asc: false},
 		OutputJson: true,
 		Fields:     []consts.FieldType{consts.FieldName, consts.FieldSize},
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -21,26 +21,3 @@ func validateFlagCombinations(
 
 	return nil
 }
-
-func validateConfig(cfg Config) error {
-	if err := validateSortOption(cfg.SortBy); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateSortOption(sortBy string) error {
-	validSortOptions := map[string]bool{
-		"date":         true,
-		"alphabetical": true,
-		"size:desc":    true,
-		"size:asc":     true,
-	}
-
-	if !validSortOptions[sortBy] {
-		return fmt.Errorf("Error: Invalid order option %s", sortBy)
-	}
-
-	return nil
-}

--- a/internal/consts/fields.go
+++ b/internal/consts/fields.go
@@ -45,6 +45,8 @@ var FieldTypeLookup = map[string]FieldType{
 	"R": FieldRequiredBy,
 	"p": FieldProvides,
 
+	"alphabetical": FieldName, // legacy flag, to be deprecated
+
 	date:        FieldDate,
 	name:        FieldName,
 	reason:      FieldReason,

--- a/internal/pipeline/phase/steps.go
+++ b/internal/pipeline/phase/steps.go
@@ -78,7 +78,7 @@ func SaveCacheStep(
 		// TODO: we can probably save the file concurrently
 		err := pkgdata.SaveProtoCache(pkgPtrs)
 		if err != nil {
-			out.WriteLine(fmt.Sprintf("Error saving cache: %v", err))
+			out.WriteLine(fmt.Sprintf("Warning: Error saving cache: %v", err))
 		}
 	}
 
@@ -109,7 +109,7 @@ func SortStep(
 	reportProgress ProgressReporter,
 	_ *meta.PipelineContext,
 ) ([]*PkgInfo, error) {
-	comparator := pkgdata.GetComparator(cfg.SortBy)
+	comparator := pkgdata.GetComparator(cfg.SortOption.Field, cfg.SortOption.Asc)
 	phase := "Sorting packages"
 
 	// threshold is 500 as that is where merge sorting chunk performance overtakes timsort

--- a/yaylog.1
+++ b/yaylog.1
@@ -1,10 +1,10 @@
 .\" Man page for yaylog
-.TH yaylog 1 "March 2025" "yaylog 3.39.0" "User Commands"
+.TH yaylog 1 "March 2025" "yaylog 3.40.0" "User Commands"
 .SH NAME
 yaylog \- List and query installed packages on Arch-based systems.
 .SH SYNOPSIS
 .B yaylog
-.RI [ \-n | \-\-limit <number> ] [ \-a | \-\-all ] [ \-w <field>=<value> ] [ \-s | \-\-select <list> ] [ \-S | \-\-select-add <list> ] [ \-A | \-\-select-all ] [ \-O | \-\-order <mode> ] [ \-\-json ] [ \-\-no-headers ] [ \-\-full-timestamp ] [ \-\-no-progress ] [ \-h | \-\-help ]
+.RI [ \-l | \-\-limit <number> ] [ \-a | \-\-all ] [ \-w <field>=<value> ] [ \-s | \-\-select <list> ] [ \-S | \-\-select-add <list> ] [ \-A | \-\-select-all ] [ \-O | \-\-order <field>:<direction> ] [ \-\-json ] [ \-\-no-headers ] [ \-\-full-timestamp ] [ \-\-no-progress ] [ \-h | \-\-help ]
 
 .SH DESCRIPTION
 .B yaylog
@@ -101,20 +101,21 @@ yaylog -w reason=explicit -w size=100MB:
 .EE
 
 .TP
-.B \-O, \-\-order <mode>
-Sort results by the specified mode. Available modes:
+.B \-O, \-\-order <field>:<direction>
+Sort results by the specified field, ascending or descending directions (asc/desc).
+Available fields for sorting.
 .IP
 .B date
 (default): Sort by installation date.
 .IP
-.B alphabetical
+.B name
 : Sort alphabetically by package name.
 .IP
-.B size:asc
-: Sort by size ascending.
+.B size
+: Sort by size on disk
 .IP
-.B size:desc
-: Sort by size descending.
+.B license
+: Sort alphabetically by package license.
 
 .TP
 .B \-\-no-headers
@@ -160,7 +161,7 @@ Show help information.
 .TP
 Last 10 installed packages:
 .EX
-yaylog -n 10
+yaylog -l 10
 .EE
 .TP
 All explicitly installed packages:


### PR DESCRIPTION
Users can now sort by license with `yaylog -O license`, `yaylog -O license:asc`, or `yaylog -O license:desc`. 

This patch also allows for users to sort in either direction (`:asc` | `:desc`) for all sort-able fields. 

Addresses #137 