### PR TITLE
Feature: Add license query

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,18 @@ this package is compatible with the following distributions:
 
 ## features
 
-- list installed packages with date/timestamps, dependencies, provisions, requirements, size on disk, conflicts, architecture, description, and version
+- list installed packages with date/timestamps, dependencies, provisions, requirements, size on disk, conflicts, architecture, license, description, and version
 - query by explicitly installed packages
 - query by packages installed as dependencies
 - query by packages required by specified packages
 - query by packages that depend upon specified packages
 - query by packages that provide specified packages
 - query by packages that conflict with specific packages
+- query by packages that contain specific licenses
 - query by a specific installation date or date range
 - query by packages built with specified architectures
 - query by package size or size range
-- query by package name (substring match)
+- query by package names
 - sort by installation date, package name, license, or by size on disk
 - output as a table or JSON
 
@@ -170,14 +171,15 @@ yaylog [options]
   - `--where depends=glibc`    -> query by packages that depend on `glibc`
   - `--where conflicts=sdl2`   -> query by packages that conflict with `sdl2`
   - `--where arch=x86_64`      -> query by packages that are built for `x86_64` CPUs
-- `-O` | `--order <field>:<direction>`: sort results ascending or descending (default sort is `date:asc`):
+  - `--where license=GPL`      -> query by package licenses that contain `GPL`
+- `-O <field>:<direction>` | `--order <field>:<direction>`: sort results ascending or descending (default sort is `date:asc`):
   - `date`    -> sort by installation date
   - `name`    -> sort alphabetically by package name
   - `size`    -> sort by package size on disk
   - `license` -> sort alphabetically by package license
 - `--no-headers`: omit column headers in table output (useful for scripting)
-- `-s` | `--select <list>`: comma-separated list of fields to display (cannot use with `--select-all` or `--select-add`)
-- `-S` | `--select-add <list>`: comma-separated list of fields to add to defaults or `--select-all`
+- `-s <list>` | `--select <list>`: comma-separated list of fields to display (cannot use with `--select-all` or `--select-add`)
+- `-S <list>` | `--select-add <list>`: comma-separated list of fields to add to defaults or `--select-all`
 - `-A` | `--select-all`: output all available fields (overrides defaults)
 - `--full-timestamp`: display the full timestamp (date and time) of package installations instead of just the date
 - `--json`: output results in JSON format (overrides table output and `--full-timestamp`)
@@ -185,7 +187,7 @@ yaylog [options]
 - `-h` | `--help`: print help info
 
 ### querying with `--where`
-the `--where` (short-flag: `-w`) flag allow for powerful querying of installed packages. queries can be combined by using multiple query flags. 
+the `--where` (short-flag: `-w`) flag allows for powerful querying of installed packages. queries can be combined by using multiple query flags. 
 
 all queries that take package/library/program names as arguments can also take a comma-separated list. this applies to the queries `name`, `depends`, and `required-by`. 
 
@@ -194,6 +196,7 @@ short-flag queries and long-flag queries can be combined.
 #### available queries
 | query type  | syntax | description |
 |-------------|--------|-------------|
+| **license** | `license=<license>` / <br> `license=<license-1>,<license-2>,<etc` | query by license name (substring match) |
 | **date** | `date=<value>` | query by installation date. supports exact dates, ranges (`YYYY-MM-DD:YYYY-MM-DD`), and open-ended ranges (`YYYY-MM-DD:` or `:YYYY-MM-DD`) |
 | **required by** | `required-by=<package>` / <br> `required-by=<package-1>,<package-2>,<etc>` | query by packages that are required by the specified packages |
 | **depends** | `depends=<package>` / <br> `depends=<package-1>,<package-2>,<etc>` | query by packages that have the specified packages as dependencies |
@@ -325,16 +328,16 @@ are treated as separate parameters.
    ```bash
    yaylog -a -O name
    ```
- 5. show the 15 most recent explicitly installed packages
+ 5. search for packages that contain a GPL license
    ```bash
-   yaylog -w reason=explicit -l 15
+   yaylog -w license=GPL
    ```
- 6. show packages installed between july 1, 2024, and december 31, 2024
+ 6. show packages installed between january 1, 2025, and january 5, 2025
    ```bash
-   yaylog -w date=2024-07-01:2024-12-31
+   yaylog -w date=2025-01-01:2025-01-05
    ```
  7. sort all packages by their license, displaying name and license
-   ```
+   ```bash
    yaylog -aO license -s name,license
    ```
  8. show the 20 most recently installed packages larger than 20MB
@@ -440,4 +443,8 @@ are treated as separate parameters.
 33. show all dependencies smaller than 500KB  
    ```bash
    yaylog -w reason=dependencies -w size=:500KB
+   ```
+34. show the 15 most recent explicitly installed packages
+   ```bash
+   yaylog -w reason=explicit -l 15
    ```

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ are treated as separate parameters.
    ```
  5. search for packages that contain a GPL license
    ```bash
-   yaylog -w license=GPL
+   yaylog -w license=gpl
    ```
  6. show packages installed between january 1, 2025, and january 5, 2025
    ```bash

--- a/internal/pipeline/filtering/builder.go
+++ b/internal/pipeline/filtering/builder.go
@@ -2,7 +2,6 @@ package filtering
 
 import (
 	"fmt"
-	"regexp"
 	"sort"
 	"strings"
 	"yaylog/internal/config"
@@ -14,9 +13,6 @@ type (
 	PkgInfo         = pkgdata.PkgInfo
 	FilterCondition = pkgdata.FilterCondition
 )
-
-// TODO: regex is overkill for package list parsing
-var targetListRegex = regexp.MustCompile(`^([a-z0-9][a-z0-9._-]*[a-z0-9])(,([a-z0-9][a-z0-9._-]*[a-z0-9]))*$`)
 
 func QueriesToConditions(filterQueries map[consts.FieldType]string) (
 	[]*FilterCondition,
@@ -34,7 +30,7 @@ func QueriesToConditions(filterQueries map[consts.FieldType]string) (
 		case consts.FieldSize:
 			condition, err = parseSizeFilterCondition(value)
 		case consts.FieldName, consts.FieldRequiredBy, consts.FieldDepends,
-			consts.FieldProvides, consts.FieldConflicts, consts.FieldArch:
+			consts.FieldProvides, consts.FieldConflicts, consts.FieldArch, consts.FieldLicense:
 			condition, err = parsePackageFilterCondition(fieldType, value)
 		case consts.FieldReason:
 			condition, err = parseReasonFilterCondition(value)
@@ -61,10 +57,6 @@ func parsePackageFilterCondition(
 	fieldType consts.FieldType,
 	targetListInput string,
 ) (*FilterCondition, error) {
-	if !targetListRegex.MatchString(targetListInput) {
-		return nil, fmt.Errorf("invalid package list: %s", targetListInput)
-	}
-
 	targetList := strings.Split(targetListInput, ",")
 	return newPackageCondition(fieldType, targetList)
 }

--- a/internal/pipeline/filtering/conditions.go
+++ b/internal/pipeline/filtering/conditions.go
@@ -2,6 +2,7 @@ package filtering
 
 import (
 	"fmt"
+	"strings"
 	"yaylog/internal/consts"
 	"yaylog/internal/pkgdata"
 )
@@ -27,6 +28,10 @@ func newPackageCondition(fieldType consts.FieldType, targets []string) (*FilterC
 	conditionFilter := newBaseCondition(fieldType)
 	var filterFunc pkgdata.Filter
 
+	for i, target := range targets {
+		targets[i] = strings.ToLower(target)
+	}
+
 	switch fieldType {
 	case consts.FieldName:
 		filterFunc = func(pkg *PkgInfo) bool {
@@ -35,6 +40,10 @@ func newPackageCondition(fieldType consts.FieldType, targets []string) (*FilterC
 	case consts.FieldArch:
 		filterFunc = func(pkg *PkgInfo) bool {
 			return pkgdata.FilterByStrings(pkg.Arch, targets)
+		}
+	case consts.FieldLicense:
+		filterFunc = func(pkg *PkgInfo) bool {
+			return pkgdata.FilterByStrings(pkg.License, targets)
 		}
 	case consts.FieldRequiredBy:
 		filterFunc = func(pkg *PkgInfo) bool {

--- a/internal/pkgdata/filters.go
+++ b/internal/pkgdata/filters.go
@@ -45,7 +45,7 @@ func FilterDependencies(pkg *PkgInfo) bool {
 // filters for packages installed on specific date
 func FilterByDate(pkg *PkgInfo, date int64) bool {
 	pkgDate := time.Unix(pkg.Timestamp, 0)
-	targetDate := time.Unix(date, 0)
+	targetDate := time.Unix(date, 0) // TODO: we can pull this out to the top level
 	return pkgDate.Year() == targetDate.Year() && pkgDate.YearDay() == targetDate.YearDay()
 }
 
@@ -76,6 +76,8 @@ func FilterBySizeRange(pkg *PkgInfo, startSize int64, endSize int64) bool {
 }
 
 func FilterByStrings(pkgString string, targetStrings []string) bool {
+	pkgString = strings.ToLower(pkgString)
+
 	for _, targetString := range targetStrings {
 		if strings.Contains(pkgString, targetString) {
 			return true

--- a/yaylog.1
+++ b/yaylog.1
@@ -1,5 +1,5 @@
 .\" Man page for yaylog
-.TH yaylog 1 "March 2025" "yaylog 3.40.0" "User Commands"
+.TH yaylog 1 "March 2025" "yaylog 3.41.0" "User Commands"
 .SH NAME
 yaylog \- List and query installed packages on Arch-based systems.
 .SH SYNOPSIS
@@ -20,7 +20,8 @@ The utility provides powerful querying capabilities, including:
 - Installation date queries
 - Package size queries
 - Install reason queries
-- Reverse dependency lookups
+- License queries
+- Reverse dependency queries (requirements)
 - Conflict queries
 - Dependency queries
 - Provision queries
@@ -48,6 +49,9 @@ Apply package queries. This option can be used multiple times.
 
 .PP
 Supported queries:
+.IP
+.B license=<license-name>
+: Packages that contain the specified license. Supports comma-separated list.
 .IP
 .B date=<YYYY-MM-DD>
 : Packages installed on the specified date.


### PR DESCRIPTION
Users can now query by license with `-w license=<license-name>`

Example:
```bash
> yaylog -w license=gpl --columns name,license
NAME                           LICENSE
fakeroot                       GPL-3.0-or-later
most                           GPL
slang                          GPL
python-autocommand             LGPL
perl-params-util               GPL
perl-parallel-forkmanager      GPL
perl-sub-quote                 GPL
perl-class-method-modifiers    GPL
perl-sub-exporter-progressive  GPL
perl-role-tiny                 GPL
perl-sub-install               GPL
perl-sub-exporter              GPL
perl-moo                       GPL
perl-data-optlist              GPL
perl-devel-globaldestruction   GPL
perl-import-into               GPL
cloc                           GPL-2.0-or-later
asciinema                      GPL-3.0-only
pacman-contrib                 GPL-2.0-or-later
golangci-lint-bin              GPL-3.0
```

Addresses #139 