### PR TITLE
Refactor: Adjust output concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ are treated as separate parameters.
   ```
   string arguments can also be surrounded with quotes or double-quotes:
   ```bash
-  yaylog --order="alphabetical" -w name="vim"
+  yaylog --order="name" -w name="vim"
   ```
 
   this can be useful for scripts and automation where you might want to avoid any and all ambiguity.

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ are treated as separate parameters.
    ```
  4. show all packages sorted alphabetically by name
    ```bash
-   yaylog -a -O name
+   yaylog -aO name
    ```
  5. search for packages that contain a GPL license
    ```bash

--- a/README.md
+++ b/README.md
@@ -289,8 +289,8 @@ are treated as separate parameters.
   ```
 - all options that take an argument can also be used in the `--<flag>=<argument>` format:
   ```bash
-  yaylog -w size=100MB:1GB -w date=:2024-06-30 --limit=100
-  yaylog -w name=gtk -O=alphabetical
+  yaylog --select-add=name --limit=100
+  yaylog -s=date,name,version -O=name
   ```
   boolean flags can also be explicitly set using `--<flag>=true` or `--<flag>=false`:
   ```bash

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ because yay is my preferred AUR helper and the name has a good flow.
 - [x] architecture query
 - [x] optimize query order (4% speed boost)
 - [ ] dependency count sort
-- [ ] license query
+- [x] license query
 - [ ] optional dependency field
 - [x] improve sorting efficiency (8% speed boost)
 - [ ] package base field

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,7 +42,6 @@ type CliConfigProvider struct{}
 func (c *CliConfigProvider) GetConfig() (Config, error) {
 	cfg, err := ParseFlags(os.Args[1:])
 	if err != nil {
-		pflag.PrintDefaults()
 		return Config{}, err
 	}
 
@@ -82,7 +81,7 @@ func ParseFlags(args []string) (Config, error) {
 	pflag.BoolVarP(&allPackages, "all", "a", false, "Show all packages (ignores -l)")
 
 	pflag.StringArrayVarP(&filterInputs, "where", "w", []string{}, "Apply multiple filters (e.g. --where size=2KB:3KB --w name=vim)")
-	pflag.StringVarP(&sortInput, "order", "O", "date", "Order results by a field")
+	pflag.StringVarP(&sortInput, "order", "O", "date", "Order results by field")
 
 	pflag.BoolVarP(&hasNoHeaders, "no-headers", "", false, "Hide headers for table ouput (useful for scripts/automation)")
 	pflag.BoolVarP(&hasAllFields, "select-all", "A", false, "Display all available fields")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,7 +80,7 @@ func ParseFlags(args []string) (Config, error) {
 	pflag.IntVarP(&count, "limit", "l", 20, "Number of packages to show")
 	pflag.BoolVarP(&allPackages, "all", "a", false, "Show all packages (ignores -l)")
 
-	pflag.StringArrayVarP(&filterInputs, "where", "w", []string{}, "Apply multiple filters (e.g. --where size=2KB:3KB --w name=vim)")
+	pflag.StringArrayVarP(&filterInputs, "where", "w", []string{}, "Apply multiple filters (e.g. --where size=2KB:3KB -wname=vim)")
 	pflag.StringVarP(&sortInput, "order", "O", "date", "Order results by field")
 
 	pflag.BoolVarP(&hasNoHeaders, "no-headers", "", false, "Hide headers for table ouput (useful for scripts/automation)")

--- a/internal/display/output_manager.go
+++ b/internal/display/output_manager.go
@@ -76,8 +76,6 @@ func (o *OutputManager) writeLine(msg string) {
 }
 
 func (o *OutputManager) printProgress(phase string, progress int, description string) {
-	o.progressActive = true
-
 	msg := o.formatProgessMsg(phase, progress, description)
 	o.clearPrevMsg(len(msg))
 
@@ -86,10 +84,7 @@ func (o *OutputManager) printProgress(phase string, progress int, description st
 }
 
 func (o *OutputManager) clearProgress() {
-	if o.progressActive {
-		o.clearPrevMsg(0)
-		o.progressActive = false
-	}
+	o.clearPrevMsg(0)
 }
 
 func (o *OutputManager) formatProgessMsg(phase string, progress int, description string) string {


### PR DESCRIPTION
Preventing a race condition by removing a superfluous state check on output manager. 